### PR TITLE
Improve preview handling

### DIFF
--- a/api/cameracontrol.py
+++ b/api/cameracontrol.py
@@ -1,11 +1,6 @@
 #!/usr/bin/env python
 
-import signal
-import sys
-import time
-import psutil
-import zmq
-import argparse
+import os, signal, sys, time, psutil, zmq, argparse
 from argparse import Namespace
 from subprocess import Popen, PIPE
 import gphoto2 as gp
@@ -256,9 +251,8 @@ class MessageSender:
 
 def get_running_pid():
     for p in psutil.process_iter(['name', 'cmdline']):
-        if p.name() == 'python3':
-            if p.cmdline()[1].endswith('cameracontrol.py'):
-                return p.pid
+        if p.name() == 'python3' and p.cmdline()[1].endswith('cameracontrol.py') and p.pid != os.getpid():
+            return p.pid
     return -1
 
 

--- a/api/cameracontrol.py
+++ b/api/cameracontrol.py
@@ -254,13 +254,12 @@ class MessageSender:
             print('Interrupted!')
 
 
-def is_already_running():
-    instances = 0
+def get_running_pid():
     for p in psutil.process_iter(['name', 'cmdline']):
         if p.name() == 'python3':
             if p.cmdline()[1].endswith('cameracontrol.py'):
-                instances += 1
-    return instances > 1
+                return p.pid
+    return -1
 
 
 def main():
@@ -289,10 +288,12 @@ def main():
     parser.add_argument('--exit', action='store_true', help='exit the service')
 
     args = parser.parse_args()
-    if not is_already_running():
-        CameraControl(args)
-    else:
+    pid = get_running_pid()
+    if pid > 0:
         MessageSender(vars(args))
+        print(pid)
+    else:
+        CameraControl(args)
 
 
 if __name__ == '__main__':

--- a/api/takeVideo.php
+++ b/api/takeVideo.php
@@ -33,7 +33,9 @@ if ($_POST['play'] === 'true') {
     die($LogString);
 } elseif ($_POST['play'] === 'false') {
     $killcmd = sprintf($config['preview']['killcmd']);
-    exec($killcmd);
+    if ($killcmd != '') {
+        exec($killcmd);
+    }
 
     $LogData = [
         'isRunning' => isRunning($_POST['pid']),

--- a/api/takeVideo.php
+++ b/api/takeVideo.php
@@ -38,8 +38,8 @@ if ($_POST['play'] === 'true') {
     }
 
     $LogData = [
-        'isRunning' => isRunning($_POST['pid']),
-        'pid' => $_POST['pid'],
+        'isRunning' => isRunning($_POST[')pid']),
+        'pid' => intval($_POST['pid']),
         'php' => basename($_SERVER['PHP_SELF']),
     ];
     $LogString = json_encode($LogData);

--- a/api/takeVideo.php
+++ b/api/takeVideo.php
@@ -38,7 +38,7 @@ if ($_POST['play'] === 'true') {
     }
 
     $LogData = [
-        'isRunning' => isRunning($_POST[')pid']),
+        'isRunning' => isRunning($_POST['pid']),
         'pid' => intval($_POST['pid']),
         'php' => basename($_SERVER['PHP_SELF']),
     ];

--- a/index.php
+++ b/index.php
@@ -81,7 +81,7 @@ if (
 </head>
 
 <body class="deselect">
-<video id="video--preview" class="<?php echo $config['preview']['flip']; ?> <?php echo $config['preview']['style']; ?>"
+<video id="video--view" class="<?php echo $config['preview']['flip']; ?> <?php echo $config['preview']['style']; ?>"
        autoplay playsinline></video>
 <div id="blocker"></div>
 <div id="aperture"></div>
@@ -112,10 +112,6 @@ if (
             </div>
 
             <div id="ipcam--view" class="<?php echo $config['preview']['style']; ?>"></div>
-
-            <video id="video--view"
-                   class="<?php echo $config['preview']['flip']; ?> <?php echo $config['preview']['style']; ?>"
-                   autoplay></video>
 
             <div id="counter">
                 <canvas id="video--sensor"></canvas>

--- a/index.php
+++ b/index.php
@@ -49,163 +49,177 @@ if (
 <html>
 
 <head>
-	<meta charset="UTF-8" />
-	<meta name="viewport" content="width=device-width, initial-scale=1.0 user-scalable=no">
-	<meta name="msapplication-TileColor" content="<?=$config['colors']['primary']?>">
-	<meta name="theme-color" content="<?=$config['colors']['primary']?>">
+    <meta charset="UTF-8"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0 user-scalable=no">
+    <meta name="msapplication-TileColor" content="<?= $config['colors']['primary'] ?>">
+    <meta name="theme-color" content="<?= $config['colors']['primary'] ?>">
 
-	<title><?=$config['ui']['branding']?></title>
+    <title><?= $config['ui']['branding'] ?></title>
 
-	<!-- Favicon + Android/iPhone Icons -->
-	<link rel="apple-touch-icon" sizes="180x180" href="resources/img/apple-touch-icon.png">
-	<link rel="icon" type="image/png" sizes="32x32" href="resources/img/favicon-32x32.png">
-	<link rel="icon" type="image/png" sizes="16x16" href="resources/img/favicon-16x16.png">
-	<link rel="manifest" href="resources/img/site.webmanifest">
-	<link rel="mask-icon" href="resources/img/safari-pinned-tab.svg" color="#5bbad5">
+    <!-- Favicon + Android/iPhone Icons -->
+    <link rel="apple-touch-icon" sizes="180x180" href="resources/img/apple-touch-icon.png">
+    <link rel="icon" type="image/png" sizes="32x32" href="resources/img/favicon-32x32.png">
+    <link rel="icon" type="image/png" sizes="16x16" href="resources/img/favicon-16x16.png">
+    <link rel="manifest" href="resources/img/site.webmanifest">
+    <link rel="mask-icon" href="resources/img/safari-pinned-tab.svg" color="#5bbad5">
 
-	<!-- Fullscreen Mode on old iOS-Devices when starting photobooth from homescreen -->
-	<meta name="apple-mobile-web-app-capable" content="yes" />
-	<meta name="apple-mobile-web-app-status-bar-style" content="black" />
+    <!-- Fullscreen Mode on old iOS-Devices when starting photobooth from homescreen -->
+    <meta name="apple-mobile-web-app-capable" content="yes"/>
+    <meta name="apple-mobile-web-app-status-bar-style" content="black"/>
 
-	<link rel="stylesheet" href="node_modules/normalize.css/normalize.css" />
-	<link rel="stylesheet" href="node_modules/font-awesome/css/font-awesome.css" />
-	<link rel="stylesheet" href="vendor/PhotoSwipe/dist/photoswipe.css" />
-	<link rel="stylesheet" href="vendor/PhotoSwipe/dist/default-skin/default-skin.css" />
-	<link rel="stylesheet" href="resources/css/<?php echo $config['ui']['style']; ?>_style.css" />
-	<?php if ($config['gallery']['bottom_bar']): ?>
-	<link rel="stylesheet" href="resources/css/photoswipe-bottom.css" />
-	<?php endif; ?>
-	<?php if (is_file("private/overrides.css")): ?>
-	<link rel="stylesheet" href="private/overrides.css" />
-	<?php endif; ?>
+    <link rel="stylesheet" href="node_modules/normalize.css/normalize.css"/>
+    <link rel="stylesheet" href="node_modules/font-awesome/css/font-awesome.css"/>
+    <link rel="stylesheet" href="vendor/PhotoSwipe/dist/photoswipe.css"/>
+    <link rel="stylesheet" href="vendor/PhotoSwipe/dist/default-skin/default-skin.css"/>
+    <link rel="stylesheet" href="resources/css/<?php echo $config['ui']['style']; ?>_style.css"/>
+    <?php if ($config['gallery']['bottom_bar']): ?>
+        <link rel="stylesheet" href="resources/css/photoswipe-bottom.css"/>
+    <?php endif; ?>
+    <?php if (is_file("private/overrides.css")): ?>
+        <link rel="stylesheet" href="private/overrides.css"/>
+    <?php endif; ?>
 </head>
 
-<video id="video--preview" class="<?php echo $config['preview']['flip']; ?> <?php echo $config['preview']['style']; ?>" autoplay playsinline></video>
 <body class="deselect">
+<video id="video--preview" class="<?php echo $config['preview']['flip']; ?> <?php echo $config['preview']['style']; ?>"
+       autoplay playsinline></video>
 <div id="blocker"></div>
 <div id="aperture"></div>
-	<div id="wrapper">
-		<?php include('template/' . $config['ui']['style'] . '.template.php'); ?>
+<div id="wrapper">
+    <?php include('template/' . $config['ui']['style'] . '.template.php'); ?>
 
-		<!-- image Filter Pane -->
-		<?php if ($config['filters']['enabled']): ?>
-		<div id="mySidenav" class="dragscroll sidenav rotarygroup">
-			<a href="#" class="<?php echo $btnClass; ?> closebtn rotaryfocus"><i class="fa fa-times"></i></a>
+    <!-- image Filter Pane -->
+    <?php if ($config['filters']['enabled']): ?>
+        <div id="mySidenav" class="dragscroll sidenav rotarygroup">
+            <a href="#" class="<?php echo $btnClass; ?> closebtn rotaryfocus"><i class="fa fa-times"></i></a>
 
-			<?php foreach(AVAILABLE_FILTERS as $filter => $name): ?>
-				<?php if (!in_array($filter, $config['filters']['disabled'])): ?>
-					<div id="<?=$filter?>" class="filter <?php if($config['filters']['defaults'] === $filter)echo 'activeSidenavBtn'; ?>">
-						<a class="btn btn--small rotaryfocus" href="#"><?=$name?></a>
-					</div>
-				<?php endif; ?>
-			<?php endforeach; ?>
-		</div>
-		<?php endif; ?>
+            <?php foreach (AVAILABLE_FILTERS as $filter => $name): ?>
+                <?php if (!in_array($filter, $config['filters']['disabled'])): ?>
+                    <div id="<?= $filter ?>"
+                         class="filter <?php if ($config['filters']['defaults'] === $filter) echo 'activeSidenavBtn'; ?>">
+                        <a class="btn btn--small rotaryfocus" href="#"><?= $name ?></a>
+                    </div>
+                <?php endif; ?>
+            <?php endforeach; ?>
+        </div>
+    <?php endif; ?>
 
-		<!-- Loader -->
-		<div class="stages" id="loader">
-			<div class="loaderInner">
-				<div class="spinner">
-					<i class="fa fa-cog fa-spin"></i>
-				</div>
+    <!-- Loader -->
+    <div class="stages" id="loader">
+        <div class="loaderInner">
+            <div class="spinner">
+                <i class="fa fa-cog fa-spin"></i>
+            </div>
 
-				<div id="ipcam--view" class="<?php echo $config['preview']['style']; ?>"></div>
+            <div id="ipcam--view" class="<?php echo $config['preview']['style']; ?>"></div>
 
-				<video id="video--view" class="<?php echo $config['preview']['flip']; ?> <?php echo $config['preview']['style']; ?>" autoplay></video>
+            <video id="video--view"
+                   class="<?php echo $config['preview']['flip']; ?> <?php echo $config['preview']['style']; ?>"
+                   autoplay></video>
 
-				<div id="counter">
-					<canvas id="video--sensor"></canvas>
-				</div>
-				<div class="cheese"></div>
-				<div class="loaderImage"></div>
-				<div class="loading rotarygroup"></div>
-			</div>
-		</div>
+            <div id="counter">
+                <canvas id="video--sensor"></canvas>
+            </div>
+            <div class="cheese"></div>
+            <div class="loaderImage"></div>
+            <div class="loading rotarygroup"></div>
+        </div>
+    </div>
 
-		<!-- Result Page -->
-		<div class="stages rotarygroup" id="result">
+    <!-- Result Page -->
+    <div class="stages rotarygroup" id="result">
 
-			<div class="resultInner hidden">
-				<?php if ($config['button']['homescreen']): ?>
-				<a href="#" class="<?php echo $btnClass; ?> homebtn rotaryfocus"><i class="fa fa-home"></i> <span data-i18n="home"></span></a>
-				<?php endif; ?>
+        <div class="resultInner hidden">
+            <?php if ($config['button']['homescreen']): ?>
+                <a href="#" class="<?php echo $btnClass; ?> homebtn rotaryfocus"><i class="fa fa-home"></i> <span
+                            data-i18n="home"></span></a>
+            <?php endif; ?>
 
-				<?php if ($config['gallery']['enabled']): ?>
-				<a href="#" class="<?php echo $btnClass; ?> gallery-button rotaryfocus" ><i class="fa <?php echo $galleryIcon; ?>"></i> <span data-i18n="gallery"></span></a>
-				<?php endif; ?>
+            <?php if ($config['gallery']['enabled']): ?>
+                <a href="#" class="<?php echo $btnClass; ?> gallery-button rotaryfocus"><i
+                            class="fa <?php echo $galleryIcon; ?>"></i> <span data-i18n="gallery"></span></a>
+            <?php endif; ?>
 
-				<?php if ($config['qr']['enabled']): ?>
-				<a href="#" class="<?php echo $btnClass; ?> qrbtn rotaryfocus"><i class="fa fa-qrcode"></i> <span data-i18n="qr"></span></a>
-				<?php endif; ?>
+            <?php if ($config['qr']['enabled']): ?>
+                <a href="#" class="<?php echo $btnClass; ?> qrbtn rotaryfocus"><i class="fa fa-qrcode"></i> <span
+                            data-i18n="qr"></span></a>
+            <?php endif; ?>
 
-				<?php if ($config['mail']['enabled']): ?>
-				<a href="#" class="<?php echo $btnClass; ?> mailbtn rotaryfocus"><i class="fa fa-envelope"></i> <span data-i18n="mail"></span></a>
-				<?php endif; ?>
+            <?php if ($config['mail']['enabled']): ?>
+                <a href="#" class="<?php echo $btnClass; ?> mailbtn rotaryfocus"><i class="fa fa-envelope"></i> <span
+                            data-i18n="mail"></span></a>
+            <?php endif; ?>
 
-				<?php if ($config['print']['from_result']): ?>
-				<a href="#" class="<?php echo $btnClass; ?> printbtn rotaryfocus"><i class="fa fa-print"></i> <span data-i18n="print"></span></a>
-				<?php endif; ?>
+            <?php if ($config['print']['from_result']): ?>
+                <a href="#" class="<?php echo $btnClass; ?> printbtn rotaryfocus"><i class="fa fa-print"></i> <span
+                            data-i18n="print"></span></a>
+            <?php endif; ?>
 
-				<?php if (!$config['button']['force_buzzer']): ?>
-					<?php if (!($config['collage']['enabled'] && $config['collage']['only'])): ?>
-					<a href="#" class="<?php echo $btnClass; ?> newpic rotaryfocus"><i class="fa fa-camera"></i> <span data-i18n="newPhoto"></span></a>
-					<?php endif; ?>
+            <?php if (!$config['button']['force_buzzer']): ?>
+                <?php if (!($config['collage']['enabled'] && $config['collage']['only'])): ?>
+                    <a href="#" class="<?php echo $btnClass; ?> newpic rotaryfocus"><i class="fa fa-camera"></i> <span
+                                data-i18n="newPhoto"></span></a>
+                <?php endif; ?>
 
-					<?php if ($config['collage']['enabled']): ?>
-					<a href="#" class="<?php echo $btnClass; ?> newcollage rotaryfocus"><i class="fa fa-th-large"></i> <span
-							data-i18n="newCollage"></span></a>
-					<?php endif; ?>
-				<?php endif; ?>
+                <?php if ($config['collage']['enabled']): ?>
+                    <a href="#" class="<?php echo $btnClass; ?> newcollage rotaryfocus"><i class="fa fa-th-large"></i>
+                        <span
+                                data-i18n="newCollage"></span></a>
+                <?php endif; ?>
+            <?php endif; ?>
 
-				<?php if ($config['filters']['enabled']): ?>
-				<a href="#" class="<?php echo $btnClass; ?> imageFilter rotaryfocus"><i class="fa fa-magic"></i> <span data-i18n="selectFilter"></span></a>
-				<?php endif; ?>
+            <?php if ($config['filters']['enabled']): ?>
+                <a href="#" class="<?php echo $btnClass; ?> imageFilter rotaryfocus"><i class="fa fa-magic"></i> <span
+                            data-i18n="selectFilter"></span></a>
+            <?php endif; ?>
 
-				<?php if ($config['picture']['allow_delete']): ?>
-				<a href="#" class="<?php echo $btnClass; ?> deletebtn <?php if ($config['delete']['no_request']){ echo 'rotaryfocus';} ?> "><i class="fa fa-trash"></i> <span data-i18n="delete"></span></a>
-				<?php endif; ?>
-			</div>
+            <?php if ($config['picture']['allow_delete']): ?>
+                <a href="#" class="<?php echo $btnClass; ?> deletebtn <?php if ($config['delete']['no_request']) {
+                    echo 'rotaryfocus';
+                } ?> "><i class="fa fa-trash"></i> <span data-i18n="delete"></span></a>
+            <?php endif; ?>
+        </div>
 
-			<?php if ($config['qr']['enabled']): ?>
-			<div id="qrCode" class="modal">
-				<div class="modal__body"></div>
-			</div>
-			<?php endif; ?>
-		</div>
+        <?php if ($config['qr']['enabled']): ?>
+            <div id="qrCode" class="modal">
+                <div class="modal__body"></div>
+            </div>
+        <?php endif; ?>
+    </div>
 
-		<?php if ($config['gallery']['enabled']): ?>
-		<?php include('template/gallery.template.php'); ?>
-		<?php endif; ?>
-	</div>
+    <?php if ($config['gallery']['enabled']): ?>
+        <?php include('template/gallery.template.php'); ?>
+    <?php endif; ?>
+</div>
 
-	<?php include('template/pswp.template.php'); ?>
+<?php include('template/pswp.template.php'); ?>
 
-	<?php include('template/send-mail.template.php'); ?>
+<?php include('template/send-mail.template.php'); ?>
 
-	<div class="modal" id="print_mesg">
-		<div class="modal__body"><span data-i18n="printing"></span></div>
-	</div>
+<div class="modal" id="print_mesg">
+    <div class="modal__body"><span data-i18n="printing"></span></div>
+</div>
 
-	<div id="adminsettings">
-		<div style="position:absolute; bottom:0; right:0;">
-			<img src="resources/img/spacer.png" alt="adminsettings" ondblclick="adminsettings()" />
-		</div>
-	</div>
+<div id="adminsettings">
+    <div style="position:absolute; bottom:0; right:0;">
+        <img src="resources/img/spacer.png" alt="adminsettings" ondblclick="adminsettings()"/>
+    </div>
+</div>
 
-	<script src="node_modules/whatwg-fetch/dist/fetch.umd.js"></script>
-	<script type="text/javascript" src="api/config.php"></script>
-	<script type="text/javascript" src="resources/js/adminshortcut.js"></script>
-	<script type="text/javascript" src="node_modules/jquery/dist/jquery.min.js"></script>
-	<script type="text/javascript" src="vendor/PhotoSwipe/dist/photoswipe.min.js"></script>
-	<script type="text/javascript" src="vendor/PhotoSwipe/dist/photoswipe-ui-default.min.js"></script>
-	<script type="text/javascript" src="resources/js/tools.js"></script>
-	<script type="text/javascript" src="resources/js/remotebuzzer_client.js"></script>
-	<script type="text/javascript" src="resources/js/photoinit.js"></script>
-	<script type="text/javascript" src="resources/js/theme.js"></script>
-	<script type="text/javascript" src="resources/js/core.js"></script>
-	<script src="node_modules/@andreasremdt/simple-translator/dist/umd/translator.min.js"></script>
-	<script type="text/javascript" src="resources/js/i18n.js"></script>
+<script src="node_modules/whatwg-fetch/dist/fetch.umd.js"></script>
+<script type="text/javascript" src="api/config.php"></script>
+<script type="text/javascript" src="resources/js/adminshortcut.js"></script>
+<script type="text/javascript" src="node_modules/jquery/dist/jquery.min.js"></script>
+<script type="text/javascript" src="vendor/PhotoSwipe/dist/photoswipe.min.js"></script>
+<script type="text/javascript" src="vendor/PhotoSwipe/dist/photoswipe-ui-default.min.js"></script>
+<script type="text/javascript" src="resources/js/tools.js"></script>
+<script type="text/javascript" src="resources/js/remotebuzzer_client.js"></script>
+<script type="text/javascript" src="resources/js/photoinit.js"></script>
+<script type="text/javascript" src="resources/js/theme.js"></script>
+<script type="text/javascript" src="resources/js/core.js"></script>
+<script src="node_modules/@andreasremdt/simple-translator/dist/umd/translator.min.js"></script>
+<script type="text/javascript" src="resources/js/i18n.js"></script>
 
-	<?php require_once('lib/services_start.php'); ?>
+<?php require_once('lib/services_start.php'); ?>
 </body>
 </html>

--- a/livechroma.php
+++ b/livechroma.php
@@ -30,138 +30,146 @@ if (
 ?>
 <!doctype html>
 <html>
-	<head>
-		<meta charset="UTF-8" />
-		<meta name="viewport" content="width=device-width, initial-scale=1.0 user-scalable=no">
-		<meta name="msapplication-TileColor" content="<?=$config['colors']['primary']?>">
-		<meta name="theme-color" content="<?=$config['colors']['primary']?>">
+<head>
+    <meta charset="UTF-8"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0 user-scalable=no">
+    <meta name="msapplication-TileColor" content="<?= $config['colors']['primary'] ?>">
+    <meta name="theme-color" content="<?= $config['colors']['primary'] ?>">
 
-		<!-- Favicon + Android/iPhone Icons -->
-		<link rel="apple-touch-icon" sizes="180x180" href="resources/img/apple-touch-icon.png">
-		<link rel="icon" type="image/png" sizes="32x32" href="resources/img/favicon-32x32.png">
-		<link rel="icon" type="image/png" sizes="16x16" href="resources/img/favicon-16x16.png">
-		<link rel="manifest" href="resources/img/site.webmanifest">
-		<link rel="mask-icon" href="resources/img/safari-pinned-tab.svg" color="#5bbad5">
+    <!-- Favicon + Android/iPhone Icons -->
+    <link rel="apple-touch-icon" sizes="180x180" href="resources/img/apple-touch-icon.png">
+    <link rel="icon" type="image/png" sizes="32x32" href="resources/img/favicon-32x32.png">
+    <link rel="icon" type="image/png" sizes="16x16" href="resources/img/favicon-16x16.png">
+    <link rel="manifest" href="resources/img/site.webmanifest">
+    <link rel="mask-icon" href="resources/img/safari-pinned-tab.svg" color="#5bbad5">
 
-		<!-- Fullscreen Mode on old iOS-Devices when starting photobooth from homescreen -->
-		<meta name="apple-mobile-web-app-capable" content="yes" />
-		<meta name="apple-mobile-web-app-status-bar-style" content="black" />
+    <!-- Fullscreen Mode on old iOS-Devices when starting photobooth from homescreen -->
+    <meta name="apple-mobile-web-app-capable" content="yes"/>
+    <meta name="apple-mobile-web-app-status-bar-style" content="black"/>
 
-		<link rel="stylesheet" href="node_modules/normalize.css/normalize.css" />
-		<link rel="stylesheet" href="node_modules/font-awesome/css/font-awesome.css" />
-		<link rel="stylesheet" href="vendor/PhotoSwipe/dist/photoswipe.css" />
-		<link rel="stylesheet" href="vendor/PhotoSwipe/dist/default-skin/default-skin.css" />
-		<link rel="stylesheet" href="resources/css/<?php echo $config['ui']['style']; ?>_live_chromakeying.css" />
-		<?php if ($config['gallery']['bottom_bar']): ?>
-		<link rel="stylesheet" href="resources/css/photoswipe-bottom.css" />
-		<?php endif; ?>
-		<?php if (is_file("private/overrides.css")): ?>
-		<link rel="stylesheet" href="private/overrides.css" />
-		<?php endif; ?>
-	</head>
+    <link rel="stylesheet" href="node_modules/normalize.css/normalize.css"/>
+    <link rel="stylesheet" href="node_modules/font-awesome/css/font-awesome.css"/>
+    <link rel="stylesheet" href="vendor/PhotoSwipe/dist/photoswipe.css"/>
+    <link rel="stylesheet" href="vendor/PhotoSwipe/dist/default-skin/default-skin.css"/>
+    <link rel="stylesheet" href="resources/css/<?php echo $config['ui']['style']; ?>_live_chromakeying.css"/>
+    <?php if ($config['gallery']['bottom_bar']): ?>
+        <link rel="stylesheet" href="resources/css/photoswipe-bottom.css"/>
+    <?php endif; ?>
+    <?php if (is_file("private/overrides.css")): ?>
+        <link rel="stylesheet" href="private/overrides.css"/>
+    <?php endif; ?>
+</head>
+
 <body>
 <div id="blocker"></div>
 <div id="aperture"></div>
-	<div class="chromawrapper">
-	<div class="rotarygroup" id="start">
-		<div class="top-bar">
-			<?php if (!$config['live_keying']['enabled']): ?>
-			<a href="index.php" class="<?php echo $btnClass; ?> livechroma-close-btn rotaryfocus"><i class="fa fa-times"></i></a>
-			<?php endif; ?>
+<div class="chromawrapper">
+    <div class="rotarygroup" id="start">
+        <div class="top-bar">
+            <?php if (!$config['live_keying']['enabled']): ?>
+                <a href="index.php" class="<?php echo $btnClass; ?> livechroma-close-btn rotaryfocus"><i
+                            class="fa fa-times"></i></a>
+            <?php endif; ?>
 
-			<?php if ($config['gallery']['enabled']): ?>
-			<a href="#" class="<?php echo $btnClass ?> livechroma-gallery-btn rotaryfocus"><i class="fa fa-th"></i> <span data-i18n="gallery"></span></a>
-			<?php endif; ?>
+            <?php if ($config['gallery']['enabled']): ?>
+                <a href="#" class="<?php echo $btnClass ?> livechroma-gallery-btn rotaryfocus"><i class="fa fa-th"></i>
+                    <span data-i18n="gallery"></span></a>
+            <?php endif; ?>
+        </div>
 
-		</div>
+        <div class="canvasWrapper <?php echo $uiShape; ?> noborder initial">
+            <canvas class="<?php echo $uiShape; ?> noborder" id="mainCanvas"></canvas>
+        </div>
 
-		<div class="canvasWrapper <?php echo $uiShape; ?> noborder initial">
-			<canvas class="<?php echo $uiShape; ?> noborder" id="mainCanvas"></canvas>
-		</div>
+        <div class="chromaNote <?php echo $uiShape ?>">
+            <span data-i18n="chromaInfoBefore"></span>
+        </div>
 
-		<div class="chromaNote <?php echo $uiShape ?>">
-			<span data-i18n="chromaInfoBefore"></span>
-		</div>
+        <div class="stages" id="loader">
+            <div class="loaderInner">
+                <div class="spinner">
+                    <i class="fa fa-cog fa-spin"></i>
+                </div>
 
-		<div class="stages" id="loader">
-			<div class="loaderInner">
-				<div class="spinner">
-					<i class="fa fa-cog fa-spin"></i>
-				</div>
+                <div id="ipcam--view" class="<?php echo $config['preview']['style']; ?>"></div>
 
-				<div id="ipcam--view" class="<?php echo $config['preview']['style']; ?>"></div>
+                <video id="video--view"
+                       class="<?php echo $config['preview']['flip']; ?> <?php echo $config['preview']['style']; ?>"
+                       autoplay playsinline></video>
 
-				<video id="video--view" class="<?php echo $config['preview']['flip']; ?> <?php echo $config['preview']['style']; ?>" autoplay playsinline></video>
+                <div id="counter">
+                    <canvas id="video--sensor"></canvas>
+                </div>
+                <div class="cheese"></div>
+                <div class="loading"></div>
+            </div>
+        </div>
 
-				<div id="counter">
-					<canvas id="video--sensor"></canvas>
-				</div>
-				<div class="cheese"></div>
-				<div class="loading"></div>
-			</div>
-		</div>
+        <!-- Result Page -->
+        <div class="stages" id="result"></div>
 
-		<!-- Result Page -->
-		<div class="stages" id="result"></div>
+        <div class="backgrounds <?php echo $uiShape ?>">
+            <?php
+            $dir = $config['keying']['background_path'] . DIRECTORY_SEPARATOR;
+            $cdir = scandir($dir);
+            foreach ($cdir as $key => $value) {
+                if (!in_array($value, array(".", "..")) && !is_dir($dir . $value)) {
+                    echo '<img src="' . $dir . $value . '" class="' . $uiShape . ' backgroundPreview rotaryfocus" onclick="setBackgroundImage(this.src)">';
+                }
+            }
+            ?>
+        </div>
 
-		<div class="backgrounds <?php echo $uiShape ?>">
-			<?php
-				$dir = $config['keying']['background_path'] . DIRECTORY_SEPARATOR;
-				$cdir = scandir($dir);
-				foreach ($cdir as $key => $value) {
-					if (!in_array($value, array(".","..")) && !is_dir($dir.$value)) {
-						echo '<img src="'.$dir.$value.'" class="' . $uiShape . ' backgroundPreview rotaryfocus" onclick="setBackgroundImage(this.src)">';
-					}
-				}
-			?>
-		</div>
+        <div class="chroma-control-bar">
+            <a href="#" class="<?php echo $btnClass; ?> takeChroma livechroma rotaryfocus"><i class="fa fa-camera"></i>
+                <span data-i18n="takePhoto"></span></a>
+            <?php if ($config['picture']['allow_delete']): ?>
+                <a href="#" class="<?php echo $btnClass; ?> deletebtn livechroma"><i class="fa fa-trash"></i> <span
+                            data-i18n="delete"></span></a>
+            <?php endif; ?>
+            <a href="#" class="<?php echo $btnClass; ?> reloadPage livechroma rotaryfocus"><i class="fa fa-refresh"></i>
+                <span data-i18n="reload"></span></a>
+        </div>
+    </div>
+    <div class="rotarygroup">
 
-		<div class="chroma-control-bar">
-			<a href="#" class="<?php echo $btnClass; ?> takeChroma livechroma rotaryfocus"><i class="fa fa-camera"></i> <span data-i18n="takePhoto"></span></a>
-			<?php if ($config['picture']['allow_delete']): ?>
-			<a href="#" class="<?php echo $btnClass; ?> deletebtn livechroma"><i class="fa fa-trash"></i> <span data-i18n="delete"></span></a>
-			<?php endif; ?>
-			<a href="#" class="<?php echo $btnClass; ?> reloadPage livechroma rotaryfocus"><i class="fa fa-refresh"></i> <span data-i18n="reload"></span></a>
-		</div>
-	</div>
-	<div class="rotarygroup">
+        <div id="wrapper">
+            <?php include('template/gallery.template.php'); ?>
+        </div>
+        <?php include('template/pswp.template.php'); ?>
 
-	<div id="wrapper">
-		<?php include('template/gallery.template.php'); ?>
-	</div>
-	<?php include('template/pswp.template.php'); ?>
+        <?php include('template/send-mail.template.php'); ?>
 
-	<?php include('template/send-mail.template.php'); ?>
+        <div class="modal" id="print_mesg">
+            <div class="modal__body"><span data-i18n="printing"></span></div>
+        </div>
 
-	<div class="modal" id="print_mesg">
-		<div class="modal__body"><span data-i18n="printing"></span></div>
-	</div>
+        <script src="node_modules/whatwg-fetch/dist/fetch.umd.js"></script>
+        <script type="text/javascript" src="api/config.php"></script>
+        <script type="text/javascript" src="node_modules/jquery/dist/jquery.min.js"></script>
+        <script type="text/javascript" src="vendor/PhotoSwipe/dist/photoswipe.min.js"></script>
+        <script type="text/javascript" src="vendor/PhotoSwipe/dist/photoswipe-ui-default.min.js"></script>
+        <script type="text/javascript" src="resources/js/tools.js"></script>
+        <script type="text/javascript" src="resources/js/photoinit.js"></script>
+        <script type="text/javascript" src="resources/js/core.js"></script>
+        <?php if ($config['keying']['variant'] === 'marvinj'): ?>
+            <script type="text/javascript" src="node_modules/marvinj/marvinj/release/marvinj-1.0.js"></script>
+        <?php else: ?>
+            <script type="text/javascript" src="vendor/Seriously/seriously.js"></script>
+            <script type="text/javascript" src="vendor/Seriously/effects/seriously.chroma.js"></script>
+        <?php endif; ?>
+        <script type="text/javascript" src="resources/js/livechroma.js"></script>
+        <script type="text/javascript" src="resources/js/remotebuzzer_client.js"></script>
+        <script type="text/javascript" src="resources/js/theme.js"></script>
+        <script src="node_modules/@andreasremdt/simple-translator/dist/umd/translator.min.js"></script>
+        <script type="text/javascript" src="resources/js/i18n.js"></script>
 
-	<script src="node_modules/whatwg-fetch/dist/fetch.umd.js"></script>
-	<script type="text/javascript" src="api/config.php"></script>
-	<script type="text/javascript" src="node_modules/jquery/dist/jquery.min.js"></script>
-	<script type="text/javascript" src="vendor/PhotoSwipe/dist/photoswipe.min.js"></script>
-	<script type="text/javascript" src="vendor/PhotoSwipe/dist/photoswipe-ui-default.min.js"></script>
-	<script type="text/javascript" src="resources/js/tools.js"></script>
-	<script type="text/javascript" src="resources/js/photoinit.js"></script>
-	<script type="text/javascript" src="resources/js/core.js"></script>
-	<?php if ($config['keying']['variant'] === 'marvinj'): ?>
-	<script type="text/javascript" src="node_modules/marvinj/marvinj/release/marvinj-1.0.js"></script>
-	<?php else:?>
-	<script type="text/javascript" src="vendor/Seriously/seriously.js"></script>
-	<script type="text/javascript" src="vendor/Seriously/effects/seriously.chroma.js"></script>
-	<?php endif; ?>
-	<script type="text/javascript" src="resources/js/livechroma.js"></script>
-	<script type="text/javascript" src="resources/js/remotebuzzer_client.js"></script>
-	<script type="text/javascript" src="resources/js/theme.js"></script>
-	<script src="node_modules/@andreasremdt/simple-translator/dist/umd/translator.min.js"></script>
-	<script type="text/javascript" src="resources/js/i18n.js"></script>
+        <?php require_once('lib/services_start.php'); ?>
 
-	<?php require_once('lib/services_start.php'); ?>
-
-	<script type="text/javascript">
-		onLiveChromaKeyingView = true;
-	</script>
-
+        <script type="text/javascript">
+            onLiveChromaKeyingView = true;
+        </script>
+    </div>
+</div>
 </body>
 </html>

--- a/src/js/core.js
+++ b/src/js/core.js
@@ -150,7 +150,7 @@ const photoBooth = (function () {
         }
     };
 
-    api.changeVideoMode = function(mode) {
+    api.changeVideoMode = function (mode) {
         if (mode === CameraDisplayMode.BACKGROUND) {
             idVideoView.css('z-index', 0);
             wrapper.css('background-image', 'none');
@@ -308,7 +308,7 @@ const photoBooth = (function () {
                 .post('api/takeVideo.php', dataVideo)
                 .done(function (result) {
                     photoboothTools.console.log('Stop webcam', result);
-                    api.stopVideo()
+                    api.stopVideo();
                 })
                 .fail(function (xhr, status, result) {
                     photoboothTools.console.log('Could not stop webcam', result);
@@ -988,7 +988,11 @@ const photoBooth = (function () {
                 element.empty();
                 cb();
             }
-            if (config.preview.killcmd && config.preview.mode === PreviewMode.GPHOTO.valueOf() && !config.preview.camTakesPic && count === stop) {
+            if (config.preview.killcmd &&
+                config.preview.mode === PreviewMode.GPHOTO.valueOf() &&
+                !config.preview.camTakesPic &&
+                count === stop
+            ) {
                 api.stopPreviewVideo();
             }
             count++;

--- a/src/js/core.js
+++ b/src/js/core.js
@@ -987,10 +987,10 @@ const photoBooth = (function () {
                 element.empty();
                 cb();
             }
-            count++;
             if (config.preview.mode === PreviewMode.GPHOTO.valueOf() && !config.preview.camTakesPic && count === stop) {
                 api.stopPreviewVideo();
             }
+            count++;
         }
 
         timerFunction();

--- a/src/js/core.js
+++ b/src/js/core.js
@@ -988,7 +988,8 @@ const photoBooth = (function () {
                 element.empty();
                 cb();
             }
-            if (config.preview.killcmd &&
+            if (
+                config.preview.killcmd &&
                 config.preview.mode === PreviewMode.GPHOTO.valueOf() &&
                 !config.preview.camTakesPic &&
                 count === stop

--- a/src/js/core.js
+++ b/src/js/core.js
@@ -47,7 +47,6 @@ const photoBooth = (function () {
         blocker = $('#blocker'),
         aperture = $('#aperture'),
         idVideoView = $('#video--view'),
-        idVideoPreview = $('#video--preview'),
         idVideoSensor = $('#video--sensor'),
         webcamConstraints = {
             audio: false,
@@ -58,7 +57,6 @@ const photoBooth = (function () {
             }
         },
         videoView = idVideoView.get(0),
-        videoPreview = idVideoPreview.get(0),
         videoSensor = document.querySelector('#video--sensor'),
         usesBackgroundPreview =
             config.preview.asBackground &&
@@ -113,7 +111,7 @@ const photoBooth = (function () {
         gallery.removeClass('gallery--open');
         gallery.find('.gallery__inner').hide();
         idVideoView.hide();
-        idVideoPreview.hide();
+        idVideoView.css('z-index', 0);
         idVideoSensor.hide();
         ipcamView.hide();
     };
@@ -152,41 +150,51 @@ const photoBooth = (function () {
         }
     };
 
-    api.getAndDisplayMedia = function (mode, retry = 0) {
-        const getMedia =
-            navigator.mediaDevices.getUserMedia ||
-            navigator.mediaDevices.webkitGetUserMedia ||
-            navigator.mediaDevices.mozGetUserMedia ||
-            false;
-
-        if (!getMedia) {
-            return;
+    api.changeVideoMode = function(mode) {
+        if (mode === CameraDisplayMode.BACKGROUND) {
+            idVideoView.css('z-index', 0);
+            wrapper.css('background-image', 'none');
+            wrapper.css('background-color', 'transparent');
+        } else {
+            wrapper.css('background-color', config.colors.panel);
+            loader.css('background-color', 'transparent');
+            idVideoView.css('z-index', 99);
         }
+        idVideoView.show();
+    };
 
-        getMedia
-            .call(navigator.mediaDevices, webcamConstraints)
-            .then(function (stream) {
-                if (mode === CameraDisplayMode.BACKGROUND) {
-                    idVideoPreview.show();
-                    videoPreview.srcObject = stream;
-                    wrapper.css('background-image', 'none');
-                    wrapper.css('background-color', 'transparent');
-                } else {
-                    idVideoView.show();
+    api.getAndDisplayMedia = function (mode, retry = 0) {
+        if (api.stream) {
+            api.changeVideoMode(mode);
+        } else {
+            const getMedia =
+                navigator.mediaDevices.getUserMedia ||
+                navigator.mediaDevices.webkitGetUserMedia ||
+                navigator.mediaDevices.mozGetUserMedia ||
+                false;
+
+            if (!getMedia) {
+                return;
+            }
+
+            getMedia
+                .call(navigator.mediaDevices, webcamConstraints)
+                .then(function (stream) {
+                    api.stream = stream;
                     videoView.srcObject = stream;
-                }
-                api.stream = stream;
-            })
-            .catch(function (error) {
-                photoboothTools.console.log('Could not get user media: ', error);
-                if (config.preview.mode === PreviewMode.GPHOTO.valueOf() && retry < 3) {
-                    photoboothTools.console.logDev('Getting user media failed. Retrying. Retry: ' + retry);
-                    retry += 1;
-                    setTimeout(function () {
-                        api.getAndDisplayMedia(mode, retry);
-                    }, retryTimeout);
-                }
-            });
+                    api.changeVideoMode(mode);
+                })
+                .catch(function (error) {
+                    photoboothTools.console.log('Could not get user media: ', error);
+                    if (config.preview.mode === PreviewMode.GPHOTO.valueOf() && retry < 3) {
+                        photoboothTools.console.logDev('Getting user media failed. Retrying. Retry: ' + retry);
+                        retry += 1;
+                        setTimeout(function () {
+                            api.getAndDisplayMedia(mode, retry);
+                        }, retryTimeout);
+                    }
+                });
+        }
     };
 
     api.startWebcam = function () {
@@ -206,11 +214,6 @@ const photoBooth = (function () {
     };
 
     api.startVideo = function (mode, retry = 0) {
-        if (usesBackgroundPreview) {
-            api.stopVideo(CameraDisplayMode.BACKGROUND);
-            wrapper.css('background-color', config.colors.panel);
-        }
-
         if (config.preview.mode != PreviewMode.URL.valueOf()) {
             if (!navigator.mediaDevices || config.preview.mode === PreviewMode.NONE.valueOf()) {
                 return;
@@ -274,7 +277,7 @@ const photoBooth = (function () {
                 videoSensor.getContext('2d').drawImage(videoView, 0, 0);
             }
             if (config.preview.mode === PreviewMode.DEVICE.valueOf()) {
-                api.stopVideo(CameraDisplayMode.COUNTDOWN);
+                api.stopVideo();
             } else if (config.preview.mode === PreviewMode.GPHOTO.valueOf()) {
                 api.stopPreviewVideo();
             }
@@ -284,15 +287,14 @@ const photoBooth = (function () {
         }
     };
 
-    api.stopVideo = function (mode) {
+    api.stopVideo = function () {
+        wrapper.css('background-color', config.colors.panel);
+        loader.css('background', config.colors.panel);
+        loader.css('background-color', config.colors.panel);
         if (api.stream) {
             api.stream.getTracks()[0].stop();
-            if (mode === CameraDisplayMode.BACKGROUND) {
-                idVideoPreview.hide();
-            } else {
-                idVideoView.hide();
-            }
         }
+        idVideoView.hide();
     };
 
     api.stopPreviewVideo = function () {
@@ -306,8 +308,7 @@ const photoBooth = (function () {
                 .post('api/takeVideo.php', dataVideo)
                 .done(function (result) {
                     photoboothTools.console.log('Stop webcam', result);
-                    api.stream.getTracks()[0].stop();
-                    idVideoView.hide();
+                    api.stopVideo()
                 })
                 .fail(function (xhr, status, result) {
                     photoboothTools.console.log('Could not stop webcam', result);
@@ -987,7 +988,7 @@ const photoBooth = (function () {
                 element.empty();
                 cb();
             }
-            if (config.preview.mode === PreviewMode.GPHOTO.valueOf() && !config.preview.camTakesPic && count === stop) {
+            if (config.preview.killcmd && config.preview.mode === PreviewMode.GPHOTO.valueOf() && !config.preview.camTakesPic && count === stop) {
                 api.stopPreviewVideo();
             }
             count++;

--- a/src/sass/partials/_button.scss
+++ b/src/sass/partials/_button.scss
@@ -118,11 +118,6 @@
   }
 }
 
-.gallery-button,
-.homebtn {
-  z-index: 100;
-}
-
 .fs-button,
 .takeChroma,
 .reloadPage {

--- a/src/sass/partials/_ribbon.scss
+++ b/src/sass/partials/_ribbon.scss
@@ -5,7 +5,7 @@
   overflow: hidden;
   top: 0;
   right: 0;
-  z-index: 100;
+  z-index: 10;
   pointer-events: none;
   font-size: 0.8em;
   text-decoration: none;

--- a/src/sass/partials/_video_preview.scss
+++ b/src/sass/partials/_video_preview.scss
@@ -1,5 +1,4 @@
-#video--view,
-#video--preview {
+#video--view{
   top: 50%;
   left: 50%;
   transform: translate(-50%, -50%);
@@ -27,6 +26,7 @@
   &.flip-vertical {
     transform: translate(-50%, -50%) scaleY(-1);
   }
+  z-index: 0;
 }
 
 #ipcam--view {

--- a/src/sass/partials/_video_preview.scss
+++ b/src/sass/partials/_video_preview.scss
@@ -1,4 +1,4 @@
-#video--view{
+#video--view {
   top: 50%;
   left: 50%;
   transform: translate(-50%, -50%);


### PR DESCRIPTION
<!--
    Thank you for contributing!
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/PhotoboothProject/photobooth/blob/dev/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "x" next to an item)
<!-- Example:
- [x] Bug fix
-->

- [ ] Documentation update
- [X] Bug fix
- [X] New feature
- [ ] Other, please explain:
What started as a bugfix ended up as an improvement / rework. The change from preview to countdown failed for me at times without reason. I reworked it to use the same preview. As you can only define one preview source there's no reason to restart the preview and display the video on another element. This removes some flicker on the countdown press and is more reliable.

Also fixed that the countdown to stop the video was off by 1 and I only stop the video if a killcmd was defined.
<!--
    Please ensure your pull request is ready:

    - Please run 'yarn build' before submitting to have consistent formatting for both JavaScript & SCSS
    - Please run 'yarn eslint' to make sure there's no lint issues
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)
video--view and video--preview became one. I have to shift the z-index and change some background transparency to show / hide other elements.

#### Is there anything you'd like reviewers to focus on?
Because of my given setup I was only able to test the new preview setup with gphoto2 / cameracontrol.py preview - with and without background preview. This should be verified on distinct setups.