### PR TITLE
feature: pass filename to post cmd

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,3 +192,5 @@ If you like my work and like to keep me motivated you can buy me a coconut water
 - [s-dinda](https://github.com/s-dinda)
 - [Moarqi](https://github.com/Moarqi)
 - [kreativmonkey](https://github.com/kreativmonkey)
+- [Khaos66](https://github.com/Khaos66)
+

--- a/api/shellCommand.php
+++ b/api/shellCommand.php
@@ -10,7 +10,7 @@ switch ($mode) {
         $cmd = sprintf($config['pre_photo']['cmd']);
         break;
     case 'post-command':
-        $cmd = sprintf($config['post_photo']['cmd']);
+        $cmd = sprintf($config['post_photo']['cmd'], $_POST['filename']);
         break;
     case 'reboot':
         $cmd = 'sudo ' . sprintf($config['reboot']['cmd']);

--- a/src/js/admin.js
+++ b/src/js/admin.js
@@ -1,6 +1,6 @@
 /* globals photoboothTools */
 $(function () {
-    const shellCommand = function ($mode, $filename='') {
+    const shellCommand = function ($mode, $filename = '') {
         const command = {
             mode: $mode,
             filename: $filename

--- a/src/js/admin.js
+++ b/src/js/admin.js
@@ -1,8 +1,9 @@
 /* globals photoboothTools */
 $(function () {
-    const shellCommand = function ($mode) {
+    const shellCommand = function ($mode, $filename='') {
         const command = {
-            mode: $mode
+            mode: $mode,
+            filename: $filename
         };
 
         photoboothTools.console.log('Run' + $mode);

--- a/src/js/core.js
+++ b/src/js/core.js
@@ -353,9 +353,10 @@ const photoBooth = (function () {
         }
     };
 
-    api.shellCommand = function ($mode) {
+    api.shellCommand = function ($mode, $filename='') {
         command = {
-            mode: $mode
+            mode: $mode,
+            filename: $filename
         };
 
         photoboothTools.console.log('Run', $mode);
@@ -868,7 +869,7 @@ const photoBooth = (function () {
         preloadImage.src = imageUrl;
 
         if (config.post_photo.cmd) {
-            api.shellCommand('post-command');
+            api.shellCommand('post-command', filename);
         }
 
         takingPic = false;

--- a/src/js/core.js
+++ b/src/js/core.js
@@ -353,7 +353,7 @@ const photoBooth = (function () {
         }
     };
 
-    api.shellCommand = function ($mode, $filename='') {
+    api.shellCommand = function ($mode, $filename = '') {
         command = {
             mode: $mode,
             filename: $filename


### PR DESCRIPTION
<!--
    Thank you for contributing!
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/PhotoboothProject/photobooth/blob/dev/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "x" next to an item)
<!-- Example:
- [x] Bug fix
-->

- [x] Improvement / Feature

<!--
    Please ensure your pull request is ready:

    - Please run 'yarn build' before submitting to have consistent formatting for both JavaScript & SCSS
    - Please run 'yarn eslint' to make sure there's no lint issues
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)
Cherry-picked https://github.com/Khaos66/photobooth/commit/445714d4df66abf561513bdc29cdceaf2f8d95bc, which passes the Filename (doesn't include the full path!) to the post-cmd. This can be used to manipulate the Image (e.g. with Imagemagick) after the Picture was taken.
This might also be usefull for changes like requested here https://github.com/andi34/photobooth/issues/443.

Add Khaos66 to contributors, also run `yarn format` to match our required Code-Style.
