### PR TITLE
fix: allow capture from gphoto preview

### DIFF
--- a/api/takePic.php
+++ b/api/takePic.php
@@ -12,7 +12,7 @@ function takePicture($filename) {
         $demoFolder = __DIR__ . '/../resources/img/demo/';
         $devImg = array_diff(scandir($demoFolder), ['.', '..']);
         copy($demoFolder . $devImg[array_rand($devImg)], $filename);
-    } elseif ($config['preview']['mode'] === 'device_cam' && $config['preview']['camTakesPic']) {
+    } elseif (($config['preview']['mode'] === 'device_cam' || $config['preview']['mode'] === 'gphoto') && $config['preview']['camTakesPic']) {
         $data = $_POST['canvasimg'];
         list($type, $data) = explode(';', $data);
         list(, $data) = explode(',', $data);


### PR DESCRIPTION
<!--
    Thank you for contributing!
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/PhotoboothProject/photobooth/blob/dev/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "x" next to an item)
<!-- Example:
- [x] Bug fix
-->

- [ ] Documentation update
- [x] Bug fix
- [ ] New feature
- [ ] Other, please explain:

<!--
    Please ensure your pull request is ready:

    - Please run 'yarn build' before submitting to have consistent formatting for both JavaScript & SCSS
    - Please run 'yarn eslint' to make sure there's no lint issues
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)
Add missing preview check to be able to capture (a Screenshot) from gphoto2 preview instead executing the take picture command.
Javascript parts have been adjusted alread on commit https://github.com/PhotoboothProject/photobooth/commit/97d28852209f1d235c7a8a5c9dba6a884712fbab

#### Is there anything you'd like reviewers to focus on?
