### PR TITLE
fix(UI): fix QR close button position on result screen

### DIFF
--- a/index.php
+++ b/index.php
@@ -178,7 +178,7 @@ if (
 
         <?php if ($config['qr']['enabled']): ?>
             <div id="qrCode" class="modal">
-                <div class="modal__body"></div>
+                <div class="modal__body <?php echo $uiShape; ?>"></div>
             </div>
         <?php endif; ?>
     </div>

--- a/src/sass/classic_style.scss
+++ b/src/sass/classic_style.scss
@@ -106,6 +106,10 @@
     width: 100%;
     height: auto;
   }
+
+  .fa {
+    float: right;
+  }
 }
 
 .spacer {

--- a/src/sass/partials/_gallery.scss
+++ b/src/sass/partials/_gallery.scss
@@ -131,6 +131,12 @@
   opacity: 0.6 !important;
 }
 
+.pswp__qr {
+  button {
+    padding: 6px;
+    margin: 6px;
+  }
+}
 @media (max-width: 800px) {
   .pswp__button--arrow--left:before,
   .pswp__button--arrow--right:before {

--- a/src/sass/partials/_modal.scss
+++ b/src/sass/partials/_modal.scss
@@ -34,6 +34,10 @@
         margin: 0;
         font-size: 0.6em;
       }
+
+      button {
+        font-size: 0.6em;
+      }
     }
   }
 }


### PR DESCRIPTION
<!--
    Thank you for contributing!
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/PhotoboothProject/photobooth/blob/dev/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "x" next to an item)
<!-- Example:
- [x] Bug fix
-->

- [ ] Documentation update
- [x] Bug fix
- [ ] New feature
- [ ] Other, please explain:

<!--
    Please ensure your pull request is ready:

    - Please run 'yarn build' before submitting to have consistent formatting for both JavaScript & SCSS
    - Please run 'yarn eslint' to make sure there's no lint issues
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)
Add `float: right ` for close button of QR modal on result screen to match the gallery QR view.

Before:
![IMG_20220909_121647_780](https://user-images.githubusercontent.com/6080900/189329843-1d2c584e-7295-42d9-be6e-e6ff32a44c5a.jpg)

![IMG_20220909_121651_417](https://user-images.githubusercontent.com/6080900/189329847-78ec97d4-8f9d-4560-8498-8447e744534f.jpg)
