### PR TITLE
fix(UI): don't run shutter animation twice

### DIFF
--- a/src/js/core.js
+++ b/src/js/core.js
@@ -132,7 +132,7 @@ const photoBooth = (function () {
         initRemoteBuzzerFromDOM();
         rotaryController.focusSet('#start');
 
-        if (config.ui.shutter_cheese_img !== '') {
+        if (config.ui.shutter_animation && config.ui.shutter_cheese_img !== '') {
             blocker.css('background-image', 'url(' + config.ui.shutter_cheese_img + ')');
         }
     };
@@ -457,7 +457,7 @@ const photoBooth = (function () {
 
     api.cheese = function (photoStyle) {
         cheese.empty();
-        if (config.ui.shutter_cheese_img !== '') {
+        if (config.ui.shutter_animation && config.ui.shutter_cheese_img !== '') {
             api.shutter.start();
         } else if (photoStyle === PhotoStyle.PHOTO || photoStyle === PhotoStyle.CHROMA) {
             cheese.text(photoboothTools.getTranslation('cheese'));
@@ -496,7 +496,7 @@ const photoBooth = (function () {
     };
 
     api.callTakePicApi = function (data, retry = 0) {
-        if (config.ui.shutter_animation) {
+        if (config.ui.shutter_animation && config.ui.shutter_cheese_img === '') {
             api.shutter.start();
         }
         startTime = new Date().getTime();


### PR DESCRIPTION
<!--
    Thank you for contributing!
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/PhotoboothProject/photobooth/blob/dev/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "x" next to an item)
<!-- Example:
- [x] Bug fix
-->

- [ ] Documentation update
- [x] Bug fix
- [ ] New feature
- [ ] Other, please explain:

<!--
    Please ensure your pull request is ready:

    - Please run 'yarn build' before submitting to have consistent formatting for both JavaScript & SCSS
    - Please run 'yarn eslint' to make sure there's no lint issues
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)
Cheese image depends on activated shutter animation.
On Photobooth v4.0.0 the shutter animation was started if an image was defined independent of the shutter animation. api.shutter.stop is only executed inside api.callTakePicApi if shutter Animation is enabled.
There might be cases where api.shutter.start was executed twice, make sure it's only called once.
Start api.shutter.start where needed depending on our settings.

#### Is there anything you'd like reviewers to focus on?
