### PR TITLE
Setup private Folder for easier access

### DIFF
--- a/install-photobooth.sh
+++ b/install-photobooth.sh
@@ -723,6 +723,10 @@ general_permissions() {
     gpasswd -a www-data plugdev
     gpasswd -a www-data video
 
+    info "### Permissions for the private folder"
+    chmod g+s $INSTALLFOLDERPATH/private
+    setfacl -m u:$USERNAME:rwx $INSTALLFOLDERPATH/private
+
     touch "/var/www/.yarnrc"
     info "### Fixing permissions on .yarnrc"
     chown www-data:www-data "/var/www/.yarnrc"


### PR DESCRIPTION
Access the default user to write throw the private folder and add sticky bit for the group so every file that is created in this folder would be in the www-data group.

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/PhotoboothProject/photobooth/blob/dev/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "x" next to an item)
- [x] Bug fix #29 

Some people have permission issues while adding new files to `/var/www/html/private` folder like fonds ore backgrounds.

#### What changes did you make? (Give an overview)
The changes only effects if there is a new istallation of the Photobooth. Users who want this fix on a old installation can be run the following commands with sudo:

```bash
chmod g+s /var/www/html/private
setfacl -R -m u:<USERNAME>:rwx /var/www/html/private
```

1. Adding a sticky bit to the folder group of `../private` to prevent new files are in the `www-data` group
2. Add the default user to get write access on this specific folder (`setfacl`)