### PR TITLE
fix(admin): show 3rd line text of text on * in advanced view

### DIFF
--- a/lib/configsetup.inc.php
+++ b/lib/configsetup.inc.php
@@ -541,7 +541,7 @@ $configsetup = [
             'value' => htmlentities($config['textonpicture']['line2'] ?? ''),
         ],
         'textonpicture_line3' => [
-            'view' => 'expert',
+            'view' => 'advanced',
             'type' => 'input',
             'placeholder' => $defaultConfig['textonpicture']['line3'],
             'name' => 'textonpicture[line3]',
@@ -771,7 +771,7 @@ $configsetup = [
             'value' => htmlentities($config['textoncollage']['line2'] ?? ''),
         ],
         'textoncollage_line3' => [
-            'view' => 'expert',
+            'view' => 'advanced',
             'type' => 'input',
             'placeholder' => $defaultConfig['textoncollage']['line3'],
             'name' => 'textoncollage[line3]',
@@ -1334,7 +1334,7 @@ $configsetup = [
             'value' => htmlentities($config['textonprint']['line2'] ?? ''),
         ],
         'textonprint_line3' => [
-            'view' => 'expert',
+            'view' => 'advanced',
             'type' => 'input',
             'placeholder' => $defaultConfig['textonprint']['line3'],
             'name' => 'textonprint[line3]',


### PR DESCRIPTION

<!--
    Thank you for contributing!
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/PhotoboothProject/photobooth/blob/dev/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "x" next to an item)
<!-- Example:
- [x] Bug fix
-->

- [ ] Documentation update
- [x] Bug fix
- [ ] New feature
- [ ] Other, please explain:

<!--
    Please ensure your pull request is ready:

    - Please run 'yarn build' before submitting to have consistent formatting for both JavaScript & SCSS
    - Please run 'yarn eslint' to make sure there's no lint issues
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)
Line 1 and Line 2 have been visible in advanced view, while Line 3 was only visible in expert view. All lines should be visible in advanced view.


#### Is there anything you'd like reviewers to focus on?
