### PR TITLE
allow collage background images to be in any filetype gd understands

### DIFF
--- a/lib/collage.php
+++ b/lib/collage.php
@@ -145,8 +145,8 @@ function createCollage($srcImagePaths, $destImagePath, $filter = 'plain') {
 
     $my_collage = imagecreatetruecolor($collage_width, $collage_height);
     if (testFile(COLLAGE_BACKGROUND)) {
-        $backgroundImage = imagecreatefrompng(COLLAGE_BACKGROUND);
-        $backgroundImage = resizePngImage($backgroundImage, $collage_width, $collage_height);
+        $backgroundImage = imagecreatefromstring(file_get_contents(COLLAGE_BACKGROUND));
+        $backgroundImage = resizeImage($backgroundImage, $collage_width, $collage_height);
         imagecopy($my_collage, $backgroundImage, 0, 0, 0, 0, $collage_width, $collage_height);
     } else {
         $background = imagecolorallocate($my_collage, $bg_r, $bg_g, $bg_b);


### PR DESCRIPTION
<!--
    Thank you for contributing!
-->

#### Prerequisites checklist

- [X] I have read the [contributing guidelines](https://github.com/PhotoboothProject/photobooth/blob/dev/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "x" next to an item)
<!-- Example:
- [x] Bug fix
-->

- [ ] Documentation update
- [ ] Bug fix
- [X] New feature
- [ ] Other, please explain:

<!--
    Please ensure your pull request is ready:

    - Please run 'yarn build' before submitting to have consistent formatting for both JavaScript & SCSS
    - Please run 'yarn eslint' to make sure there's no lint issues
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)
Only png images were accepted as collage background. With this change the collage background can be of any file type that the image processing library accepts.

#### Is there anything you'd like reviewers to focus on?
