### PR TITLE
fix(documentation): remove reference to dev mode

### DIFF
--- a/faq/faq.md
+++ b/faq/faq.md
@@ -252,7 +252,7 @@ Photobooth will watch GPIOs for a PIN_DOWN event - so the hardware button needs 
 **Important: For WLAN connected screens you must make sure to set the IP address of the Photobooth web server in the admin settings - section "General"**. The loopback IP (127.0.0.1) does not work, it has to be the exact IP address of the Photobooth web server, to which the remote display connects to.
 
 Having trouble?
-- Switch Photobooth to DEV mode. (admin screen -> expert view -> general section)
+- Set Photobooth Log Level to 1. (admin screen -> general section)
 - Reload the Photobooth homepage
 - Check the browser developer console for error logs
 - Check the server logs for errors at the Debug panel: [http://localhost/admin/debugpanel.php](http://localhost/admin/debugpanel.php)

--- a/faq/faq.md
+++ b/faq/faq.md
@@ -252,7 +252,7 @@ Photobooth will watch GPIOs for a PIN_DOWN event - so the hardware button needs 
 **Important: For WLAN connected screens you must make sure to set the IP address of the Photobooth web server in the admin settings - section "General"**. The loopback IP (127.0.0.1) does not work, it has to be the exact IP address of the Photobooth web server, to which the remote display connects to.
 
 Having trouble?
-- Set Photobooth Log Level to 1. (admin screen -> general section)
+- Set Photobooth loglevel to 1 (or above). (admin screen -> general section)
 - Reload the Photobooth homepage
 - Check the browser developer console for error logs
 - Check the server logs for errors at the Debug panel: [http://localhost/admin/debugpanel.php](http://localhost/admin/debugpanel.php)

--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -310,7 +310,7 @@
   "manual:general:database_rebuild": "Rebuild the images database. Normally not required but can be used to fix a corrupted database file.",
   "manual:general:delete_no_request": "If enabled, images will be deleted without a confirm request. Delete of images can't be undone!",
   "manual:general:dependencies_button": "This will check if needed dependencies are installed.",
-  "manual:general:dev_debugpanel": "Opens the debug panel in a separate window. Make sure you have Dev-Mode enabled for more information.",
+  "manual:general:dev_debugpanel": "Opens the debug panel in a separate window. Make sure you set the loglevel to 1 (or above) for more information.",
   "manual:general:dev_demo_images": "If enabled, sample pictures will be used instead taking a picture.",
   "manual:general:dev_loglevel": "Define the loglevel. 0 = minimal logging, 1 = advanced logging, 2 = expert logging",
   "manual:general:dev_reload_on_error": "If an error occurs while taking a picture, Photobooth will reload automatically after 5 seconds.",

--- a/src/js/remotebuzzer_client.js
+++ b/src/js/remotebuzzer_client.js
@@ -80,7 +80,7 @@ function initRemoteBuzzerFromDOM() {
 
                 ioClient.on('connect_error', function () {
                     photoboothTools.console.log(
-                        'ERROR: remotebuzzer_client unable to connect to webserver ip - please ensure remotebuzzer_server is running on Photobooth server. Use Photobooth dev mode to create log file for debugging'
+                        'ERROR: remotebuzzer_client unable to connect to webserver ip - please ensure remotebuzzer_server is running on Photobooth server. Set Photobooth loglevel to 1 (or above) to create log file for debugging.'
                     );
                 });
 


### PR DESCRIPTION
<!--
    Thank you for contributing!
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/PhotoboothProject/photobooth/blob/dev/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "x" next to an item)
<!-- Example:
- [x] Bug fix
-->

- [x] Documentation update
- [ ] Bug fix
- [ ] New feature
- [ ] Other, please explain:

<!--
    Please ensure your pull request is ready:

    - Please run 'yarn build' before submitting to have consistent formatting for both JavaScript & SCSS
    - Please run 'yarn eslint' to make sure there's no lint issues
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

According to https://github.com/PhotoboothProject/photobooth/issues/11 the dev mode has been removed. Instead the same result of setting photobooth to dev mode can be achieved by setting the loglevel to 1.  
So i removed the reference to the dev mode in the FAQ, as this setting is not available anymore.  
Further more the log level can be set in the basic administration mode already, no need to enable the expert view

#### Is there anything you'd like reviewers to focus on?
