### PR TITLE
core: improve timings while taking an image (close https://github.com/andi34/photobooth/issues/343)

### DIFF
--- a/lib/config.php
+++ b/lib/config.php
@@ -172,6 +172,11 @@ if ($config['preview']['mode'] === 'gphoto') {
     $config['preview']['mode'] = 'device_cam';
 }
 
+// Preview need to be stopped before we can take an image
+if (!empty($config['preview']['killcmd']) && $config['preview']['stop_time'] < $config['picture']['cntdwn_offset']) {
+    $config['preview']['stop_time'] = $config['picture']['cntdwn_offset'] + 1;
+}
+
 $default_font = realpath($basepath . DIRECTORY_SEPARATOR . 'resources/fonts/GreatVibes-Regular.ttf');
 $default_frame = realpath($basepath . DIRECTORY_SEPARATOR . 'resources/img/frames/frame.png');
 

--- a/src/js/core.js
+++ b/src/js/core.js
@@ -306,9 +306,7 @@ const photoBooth = (function () {
                     } else {
                         api.cheese(photoStyle);
                     }
-                    setTimeout(() => {
-                        api.takePic(photoStyle, retry);
-                    }, cheeseTime);
+                    api.takePic(photoStyle, retry);
                 }
             }
         );
@@ -326,6 +324,9 @@ const photoBooth = (function () {
                 .text(`${api.nextCollageNumber + 1} / ${config.collage.limit}`)
                 .appendTo('.cheese');
         }
+        setTimeout(() => {
+            cheese.empty();
+        }, cheeseTime);
     };
 
     api.takePic = function (photoStyle, retry) {
@@ -382,7 +383,6 @@ const photoBooth = (function () {
                 if (config.ui.shutter_animation) {
                     api.shutter.stop();
                 }
-                cheese.empty();
 
                 imgFilter = config.filters.defaults;
                 $('#mySidenav .activeSidenavBtn').removeClass('activeSidenavBtn');

--- a/src/js/core.js
+++ b/src/js/core.js
@@ -182,7 +182,7 @@ const photoBooth = (function () {
             blocker.fadeTo(500, 1);
             setTimeout(() => {
                 api.shutter.stop();
-            }, 500);
+            }, config.picture.no_cheese ? 500 : cheeseTime);
         },
         stop: function () {
             aperture.show();
@@ -325,7 +325,7 @@ const photoBooth = (function () {
     api.cheese = function (photoStyle) {
         cheese.empty();
         if (config.ui.shutter_animation && config.ui.shutter_cheese_img !== '') {
-            api.shutter.start();
+            return;
         } else if (photoStyle === PhotoStyle.PHOTO || photoStyle === PhotoStyle.CHROMA) {
             cheese.text(photoboothTools.getTranslation('cheese'));
         } else {

--- a/src/js/core.js
+++ b/src/js/core.js
@@ -291,25 +291,32 @@ const photoBooth = (function () {
             photoStyle === PhotoStyle.COLLAGE ? config.collage.cntdwn_time : config.picture.cntdwn_time,
             counter,
             () => {
-                if (
-                    config.preview.mode === PreviewMode.DEVICE.valueOf() &&
-                    config.preview.camTakesPic &&
-                    !photoboothPreview.stream &&
-                    !config.dev.demo_images
-                ) {
-                    api.errorPic({
-                        error: 'No preview by device cam available!'
-                    });
+                if (config.picture.no_cheese) {
+                    photoboothTools.console.log('Cheese is disabled.');
                 } else {
-                    if (config.picture.no_cheese) {
-                        photoboothTools.console.log('Cheese is disabled.');
-                    } else {
-                        api.cheese(photoStyle);
-                    }
-                    api.takePic(photoStyle, retry);
+                    api.cheese(photoStyle);
                 }
             }
         );
+
+        const triggerCnt =
+            (photoStyle === PhotoStyle.COLLAGE ? config.collage.cntdwn_time : config.picture.cntdwn_time) -
+            config.picture.cntdwn_offset;
+        photoboothTools.console.log('Capture image in ' + triggerCnt + ' seconds.');
+        setTimeout(() => {
+            if (
+                config.preview.mode === PreviewMode.DEVICE.valueOf() &&
+                config.preview.camTakesPic &&
+                !photoboothPreview.stream &&
+                !config.dev.demo_images
+            ) {
+                api.errorPic({
+                    error: 'No preview by device cam available!'
+                });
+            } else {
+                api.takePic(photoStyle, retry);
+            }
+        }, triggerCnt * 1000);
     };
 
     api.cheese = function (photoStyle) {
@@ -860,8 +867,10 @@ const photoBooth = (function () {
         const stop =
             start > parseInt(config.preview.stop_time, 10) ? start - parseInt(config.preview.stop_time, 10) : start;
 
+        photoboothTools.console.log('Countdown started. Set to ' + current + ' seconds.');
+
         function timerFunction() {
-            element.text(Number(current) + Number(config.picture.cntdwn_offset));
+            element.text(Number(current));
             current--;
 
             element.removeClass('tick');

--- a/src/js/core.js
+++ b/src/js/core.js
@@ -180,6 +180,9 @@ const photoBooth = (function () {
     api.shutter = {
         start: function () {
             blocker.fadeTo(500, 1);
+            setTimeout(() => {
+                api.shutter.stop();
+            }, 500);
         },
         stop: function () {
             aperture.show();
@@ -387,10 +390,6 @@ const photoBooth = (function () {
                 totalTime = endTime - startTime;
                 photoboothTools.console.log('Took ' + data.style, result);
                 photoboothTools.console.logDev('Taking picture took ' + totalTime + 'ms');
-                if (config.ui.shutter_animation) {
-                    api.shutter.stop();
-                }
-
                 imgFilter = config.filters.defaults;
                 $('#mySidenav .activeSidenavBtn').removeClass('activeSidenavBtn');
                 $('#' + imgFilter).addClass('activeSidenavBtn');
@@ -538,9 +537,6 @@ const photoBooth = (function () {
                 }
             })
             .fail(function (xhr, status, result) {
-                if (config.ui.shutter_animation) {
-                    api.shutter.stop();
-                }
                 cheese.empty();
 
                 if (config.picture.retry_on_error > 0 && retry < config.picture.retry_on_error) {


### PR DESCRIPTION
<!--
    Thank you for contributing!
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/PhotoboothProject/photobooth/blob/dev/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "x" next to an item)
<!-- Example:
- [x] Bug fix
-->

- [ ] Documentation update
- [x] Bug fix, fix https://github.com/andi34/photobooth/issues/343
- [ ] New feature
- [ ] Other, please explain:

<!--
    Please ensure your pull request is ready:

    - Please run 'yarn build' before submitting to have consistent formatting for both JavaScript & SCSS
    - Please run 'yarn eslint' to make sure there's no lint issues
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Adjust the code to start taking an image **before** the __Cheeeeeese__ message disappears. The Cheese-Message is used to "hide" the delay we have until the camera triggers.

Also adjust the code to respect the defined offset while taking an image. The take picture action now run **independent** of the visible running countdown.

We now always also stop the shutter animation after 500ms which should look more fluid and also make sure we can't forget to stop it. If cheese is enabled cheese time will be used instead.

Don't run shutter animation twice if an cheese image is used and cheese enabled.

#### Is there anything you'd like reviewers to focus on?
