### PR TITLE
install-photobooth.sh: Explicit install apache2 in apache_webserver

### DIFF
--- a/install-photobooth.sh
+++ b/install-photobooth.sh
@@ -430,7 +430,7 @@ common_software() {
 
 apache_webserver() {
     info "### Installing Apache Webserver..."
-    apt install -y libapache2-mod-php
+    apt install -y apache2 libapache2-mod-php
 }
 
 nginx_webserver() {


### PR DESCRIPTION
Signed-off-by: Marcel <6253936+Styne13@users.noreply.github.com>

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/PhotoboothProject/photobooth/blob/dev/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "x" next to an item)
- [ ] Documentation update
- [x] Bug fix
- [ ] New feature
- [ ] Other, please explain:

#### What changes did you make? (Give an overview)
In some cases (e.g. installing on armbian) libapache2-mod-php does not install apache2.
-> add apache2 to the install function _apache_webserver_.

#### Is there anything you'd like reviewers to focus on?
