### PR TITLE
fix: start shutter animation independent of cheese image

### DIFF
--- a/src/js/core.js
+++ b/src/js/core.js
@@ -382,7 +382,7 @@ const photoBooth = (function () {
     };
 
     api.callTakePicApi = function (data, retry = 0) {
-        if (config.ui.shutter_animation && config.ui.shutter_cheese_img === '') {
+        if (config.ui.shutter_animation) {
             api.shutter.start();
         }
         startTime = new Date().getTime();


### PR DESCRIPTION
<!--
    Thank you for contributing!
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/PhotoboothProject/photobooth/blob/dev/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "x" next to an item)
<!-- Example:
- [x] Bug fix
-->

- [ ] Documentation update
- [x] Bug fix, Fix https://github.com/PhotoboothProject/photobooth/issues/117

- [ ] New feature
- [ ] Other, please explain:

<!--
    Please ensure your pull request is ready:

    - Please run 'yarn build' before submitting to have consistent formatting for both JavaScript & SCSS
    - Please run 'yarn eslint' to make sure there's no lint issues
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)
Shutter animation is started only once and independent of an defined cheese image (cheese image belongs to the blocker which is part of the animation).

#### Is there anything you'd like reviewers to focus on?
