### PR TITLE
remotebuzzer server: Determine whether or not GPIO access is possible

### DIFF
--- a/src/js/remotebuzzer_server.js
+++ b/src/js/remotebuzzer_server.js
@@ -235,7 +235,10 @@ function gpioSanity(gpioconfig) {
     }
 }
 
-if (!config.remotebuzzer.usenogpio) {
+const Gpio = require('onoff').Gpio;
+const useGpio = Gpio.accessible && !config.remotebuzzer.usenogpio;
+
+if (useGpio) {
     gpioSanity(config.remotebuzzer.picturegpio);
     gpioSanity(config.remotebuzzer.collagegpio);
     gpioSanity(config.remotebuzzer.shutdowngpio);
@@ -597,8 +600,7 @@ const watchRotaryBtn = function watchRotaryBtn(err, gpioValue) {
 };
 
 /* INIT ONOFF LIBRARY AND LINK CALLBACK FUNCTIONS */
-const Gpio = require('onoff').Gpio;
-if (!config.remotebuzzer.usenogpio) {
+if (useGpio) {
     /* ROTARY ENCODER MODE */
     if (config.remotebuzzer.userotary) {
         /* ROTARY ENCODER MODE */
@@ -672,5 +674,7 @@ if (!config.remotebuzzer.usenogpio) {
             log('Looking for Print Button on Raspberry GPIO', config.remotebuzzer.printgpio);
         }
     }
+} else if (config.remotebuzzer.usenogpio && !Gpio.accessible) {
+    log('GPIO enabled but GPIO not accessible!');
 }
 log('Initialization completed');


### PR DESCRIPTION
<!--
    Thank you for contributing!
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/PhotoboothProject/photobooth/blob/dev/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "x" next to an item)
<!-- Example:
- [x] Bug fix
-->

- [ ] Documentation update
- [ ] Bug fix
- [ ] New feature
- [x] Other, please explain: only enable GPIO support on remotebuzzer server if possible 

<!--
    Please ensure your pull request is ready:

    - Please run 'yarn build' before submitting to have consistent formatting for both JavaScript & SCSS
    - Please run 'yarn eslint' to make sure there's no lint issues
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)
Check whether or not GPIO access is possible 
https://github.com/fivdi/onoff#static-accessible

#### Is there anything you'd like reviewers to focus on?
