### PR TITLE
fix parsererror when using collage.json in php 8.1

### DIFF
--- a/lib/collage.php
+++ b/lib/collage.php
@@ -518,7 +518,7 @@ function doMath($expression): int {
     $o = 0;
     // eval is evil. To mitigate any attacks the allowed characters are limited to numbers and math symbols
     eval('$o = ' . preg_replace('/[^0-9\+\-\*\/\(\)\.]/', '', $expression) . ';');
-    return $o;
+    return intval($o);
 }
 
 function drawDashedLine($my_collage, $x1, $y1, $x2, $y2, $dashedline_color) {


### PR DESCRIPTION
<!--
    Thank you for contributing!
-->

#### Prerequisites checklist

- [X] I have read the [contributing guidelines](https://github.com/PhotoboothProject/photobooth/blob/dev/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "x" next to an item)
<!-- Example:
- [x] Bug fix
-->

- [ ] Documentation update
- [X] Bug fix
- [ ] New feature
- [ ] Other, please explain:

<!--
    Please ensure your pull request is ready:

    - Please run 'yarn build' before submitting to have consistent formatting for both JavaScript & SCSS
    - Please run 'yarn eslint' to make sure there's no lint issues
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)
Fixed a bug that cause an error message displayed (parsererror) when creating a collage that relies on collage.json when using PHP 8.1. Added intval() to prevent deprecation warning "implicit conversion from float to int" in PHP version 8.1.

#### Is there anything you'd like reviewers to focus on?
