### PR TITLE
fix: cheese image on subfolder install

### DIFF
--- a/lib/config.php
+++ b/lib/config.php
@@ -243,4 +243,9 @@ if (empty($config['qr']['url'])) {
     $config['qr']['url'] = Photobooth::get_url() . '/api/download.php?image=';
 }
 
+$config['cheese_img'] = $config['ui']['shutter_cheese_img'];
+if (!empty($config['cheese_img'])) {
+    $config['cheese_img'] = Helper::set_absolute_path($rootpath . $config['ui']['shutter_cheese_img']);
+}
+
 $config['photobooth']['version'] = Photobooth::get_photobooth_version();

--- a/src/js/core.js
+++ b/src/js/core.js
@@ -143,7 +143,7 @@ const photoBooth = (function () {
         initPhotoSwipeFromDOM('#galimages');
 
         if (config.ui.shutter_animation && config.ui.shutter_cheese_img !== '') {
-            blocker.css('background-image', 'url(' + config.ui.shutter_cheese_img + ')');
+            blocker.css('background-image', 'url(' + config.cheese_img + ')');
         }
     };
 


### PR DESCRIPTION
<!--
    Thank you for contributing!
-->

#### Prerequisites checklist

- [ ] I have read the [contributing guidelines](https://github.com/PhotoboothProject/photobooth/blob/dev/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "x" next to an item)
<!-- Example:
- [x] Bug fix
-->

- [ ] Documentation update
- [x] Bug fix
- [ ] New feature
- [ ] Other, please explain:

Close Issue #183

<!--
    Please ensure your pull request is ready:

    - Please run 'yarn build' before submitting to have consistent formatting for both JavaScript & SCSS
    - Please run 'yarn eslint' to make sure there's no lint issues
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

We're using the full path for the cheese image which will be different on a subfolder installation of photobooth
(/photobooth/private/cheese.png instead /private/cheese.png). Add a new config which will include the subfolder path if needed.

#### Is there anything you'd like reviewers to focus on?
