### PR TITLE
Bugfix: don't extend by frame on collage

### DIFF
--- a/api/print.php
+++ b/api/print.php
@@ -127,7 +127,7 @@ if (!file_exists($filename_print)) {
         }
 
         if ($config['print']['print_frame'] && testFile($config['print']['frame'])) {
-            $source = applyFrame($source, $config['print']['frame']);
+            $source = applyFrame($source, $config['print']['frame'], true);
         }
 
         list($qrWidth, $qrHeight) = getimagesize($filename_codes);
@@ -179,7 +179,7 @@ if (!file_exists($filename_print)) {
         $source = applyQR($source, $filename_codes, $x, $y);
     } else {
         if ($config['print']['print_frame'] && testFile($config['print']['frame'])) {
-            $source = applyFrame($source, $config['print']['frame']);
+            $source = applyFrame($source, $config['print']['frame'], true);
         }
     }
 

--- a/lib/applyEffects.php
+++ b/lib/applyEffects.php
@@ -50,7 +50,7 @@ function editSingleImage($config, $imageResource, $image_filter, $editSingleColl
         ($config['picture']['take_frame'] && !$isCollage && testFile($config['picture']['frame'])) ||
         ($editSingleCollage && $config['collage']['take_frame'] === 'always' && testFile($config['collage']['frame']))
     ) {
-        $imageResource = applyFrame($imageResource, $picture_frame);
+        $imageResource = applyFrame($imageResource, $picture_frame, $isCollage);
         $imageModified = true;
     }
 

--- a/lib/applyFrame.php
+++ b/lib/applyFrame.php
@@ -1,9 +1,9 @@
 <?php
 require_once __DIR__ . '/config.php';
 
-function applyFrame($sourceResource, $framePath) {
+function applyFrame($sourceResource, $framePath, $skipExtend = true) {
     global $config;
-    if ($config['picture']['extend_by_frame']) {
+    if ($config['picture']['extend_by_frame'] && !$skipExtend) {
         $frame_left_percentage = $config['picture']['frame_left_percentage'];
         $frame_right_percentage = $config['picture']['frame_right_percentage'];
         $frame_top_percentage = $config['picture']['frame_top_percentage'];

--- a/lib/collage.php
+++ b/lib/collage.php
@@ -328,7 +328,7 @@ function createCollage($srcImagePaths, $destImagePath, $filter = 'plain', Collag
                 $tempSubImage = imagecreatefromjpeg($editImages[$i]);
 
                 if ($c->collageTakeFrame === 'always' && testFile($c->collageFrame)) {
-                    $tempSubImage = applyFrame($tempSubImage, $c->collageFrame);
+                    $tempSubImage = applyFrame($tempSubImage, $c->collageFrame, true);
                 }
 
                 $tempSubImage = imagerotate($tempSubImage, $degrees, $bg_color_hex);
@@ -476,7 +476,7 @@ function createCollage($srcImagePaths, $destImagePath, $filter = 'plain', Collag
     }
 
     if ($c->collageTakeFrame === 'once' && testFile($c->collageFrame)) {
-        $my_collage = applyFrame($my_collage, $c->collageFrame);
+        $my_collage = applyFrame($my_collage, $c->collageFrame, true);
     }
 
     if ($c->textOnCollageEnabled === 'enabled' && testFile($c->textOnCollageFont)) {
@@ -556,7 +556,7 @@ function addPicture($my_collage, $filename, $pictureOptions, CollageConfig $c) {
     }
 
     if ($c->collageTakeFrame === 'always' && testFile($c->collageFrame)) {
-        $tempSubImage = applyFrame($tempSubImage, $c->collageFrame);
+        $tempSubImage = applyFrame($tempSubImage, $c->collageFrame, true);
     }
 
     if ($degrees != 0) {


### PR DESCRIPTION
<!--
    Thank you for contributing!
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/PhotoboothProject/photobooth/blob/dev/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "x" next to an item)
<!-- Example:
- [x] Bug fix
-->

- [ ] Documentation update
- [x] Bug fix
- [ ] New feature
- [ ] Other, please explain:

<!--
    Please ensure your pull request is ready:

    - Please run 'yarn build' before submitting to have consistent formatting for both JavaScript & SCSS
    - Please run 'yarn eslint' to make sure there's no lint issues
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

It's a picture only feature to extend the picture by frame, this should not apply to collage files.

#### Is there anything you'd like reviewers to focus on?
