### PR TITLE
preview: depend max-retry to take a preview from device cam on countdown

### DIFF
--- a/src/js/core.js
+++ b/src/js/core.js
@@ -270,7 +270,26 @@ const photoBooth = (function () {
 
         photoboothTools.console.log('PhotoStyle: ' + photoStyle);
 
-        photoboothPreview.startVideo(CameraDisplayMode.COUNTDOWN, retry);
+        let countdownTime;
+        switch (photoStyle) {
+            case PhotoStyle.COLLAGE:
+                countdownTime = config.collage.cntdwn_time;
+                break;
+            case PhotoStyle.VIDEO:
+                countdownTime = config.video.cntdwn_time;
+                break;
+            case PhotoStyle.CUSTOM:
+                countdownTime = config.custom.cntdwn_time;
+                break;
+            case PhotoStyle.PHOTO:
+            default:
+                countdownTime = config.picture.cntdwn_time;
+                break;
+        }
+
+        const maxGetMediaRetry = countdownTime - (config.picture.cntdwn_offset + 1);
+        console.log(maxGetMediaRetry);
+        photoboothPreview.startVideo(CameraDisplayMode.COUNTDOWN, retry, maxGetMediaRetry);
 
         if (
             config.preview.mode !== PreviewMode.NONE.valueOf() &&
@@ -309,23 +328,6 @@ const photoBooth = (function () {
             }
             const getUrl = config.get_request.server + '/' + getMode;
             photoboothTools.getRequest(getUrl);
-        }
-
-        let countdownTime;
-        switch (photoStyle) {
-            case PhotoStyle.COLLAGE:
-                countdownTime = config.collage.cntdwn_time;
-                break;
-            case PhotoStyle.VIDEO:
-                countdownTime = config.video.cntdwn_time;
-                break;
-            case PhotoStyle.CUSTOM:
-                countdownTime = config.custom.cntdwn_time;
-                break;
-            case PhotoStyle.PHOTO:
-            default:
-                countdownTime = config.picture.cntdwn_time;
-                break;
         }
 
         api.startCountdown(countdownTime, counter, () => {

--- a/src/js/preview.js
+++ b/src/js/preview.js
@@ -22,7 +22,14 @@ const photoboothPreview = (function () {
         },
         api = {};
 
-    let pid, video, loader, wrapper, url, pictureFrame, collageFrame;
+    let pid,
+        video,
+        loader,
+        wrapper,
+        url,
+        pictureFrame,
+        collageFrame,
+        retryGetMedia = 3;
 
     api.changeVideoMode = function (mode) {
         photoboothTools.console.logDev('Preview: Changing video mode: ' + mode);
@@ -71,8 +78,10 @@ const photoboothPreview = (function () {
             })
             .catch(function (error) {
                 photoboothTools.console.log('ERROR: Preview: Could not get user media: ', error);
-                if (retry < 3) {
-                    photoboothTools.console.logDev('Preview: Retrying to get user media. Retry ' + retry + ' / 3');
+                if (retry < retryGetMedia) {
+                    photoboothTools.console.logDev(
+                        'Preview: Retrying to get user media. Retry ' + retry + ' / ' + retryGetMedia
+                    );
                     retry += 1;
                     setTimeout(function () {
                         api.initializeMedia(cb, retry);
@@ -113,7 +122,8 @@ const photoboothPreview = (function () {
             });
     };
 
-    api.startVideo = function (mode, retry = 0) {
+    api.startVideo = function (mode, retry = 0, maxGetMediaRetry = 3) {
+        retryGetMedia = maxGetMediaRetry;
         photoboothTools.console.log('Preview: startVideo mode: ' + mode);
         if (config.preview.mode !== PreviewMode.URL.valueOf()) {
             if (!navigator.mediaDevices || config.preview.mode === PreviewMode.NONE.valueOf()) {


### PR DESCRIPTION
<!--
    Thank you for contributing!
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/PhotoboothProject/photobooth/blob/dev/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "x" next to an item)
<!-- Example:
- [x] Bug fix
-->

- [ ] Documentation update
- [x] Bug fix
- [ ] New feature
- [ ] Other, please explain:

<!--
    Please ensure your pull request is ready:

    - Please run 'yarn build' before submitting to have consistent formatting for both JavaScript & SCSS
    - Please run 'yarn eslint' to make sure there's no lint issues
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

If countdown is to less than 3 seconds there's no need to retry getting a preview from device cam. Besides that we can try more often on a longer countdown.

#### Is there anything you'd like reviewers to focus on?
