### PR TITLE
Add new bsm options to cameracontrol.py to not change bsm preview state & time out preview

### DIFF
--- a/api/cameracontrol.py
+++ b/api/cameracontrol.py
@@ -112,6 +112,7 @@ class CameraControl:
             self.exit_gracefully()
 
     def disable_video(self):
+        self.bsm_stopTime = None
         self.showVideo = False
         self.set_config('viewfinder', 0)
         print('Video disabled')
@@ -145,8 +146,7 @@ class CameraControl:
                 self.socket.send_string('failure')
         else:
             if args.bsm_timeOut > 0:
-                # TODO change to minutes
-                self.bsm_stopTime = datetime.now() + timedelta(seconds=args.bsm_timeOut)
+                self.bsm_stopTime = datetime.now() + timedelta(minutes=args.bsm_timeOut)
             else:
                 self.bsm_stopTime = None
             self.args.bsm = args.bsm
@@ -251,8 +251,7 @@ class CameraControl:
                     pass
                 try:
                     if self.bsm_stopTime is not None and datetime.now() > self.bsm_stopTime:
-                        self.showVideo = False
-                        self.bsm_stopTime = None
+                        self.disable_video()
                     if self.showVideo:
                         capture = self.camera.capture_preview()
                         img_bytes = memoryview(capture.get_data_and_size()).tobytes()

--- a/api/cameracontrol.py
+++ b/api/cameracontrol.py
@@ -147,6 +147,7 @@ class CameraControl:
         else:
             if args.bsm_timeOut > 0:
                 self.bsm_stopTime = datetime.now() + timedelta(minutes=args.bsm_timeOut)
+                print('Set bsm stop time to ', self.bsm_stopTime.strftime("%d.%m.%Y %H:%M:%S"))
             else:
                 self.bsm_stopTime = None
             self.args.bsm = args.bsm
@@ -251,6 +252,7 @@ class CameraControl:
                     pass
                 try:
                     if self.bsm_stopTime is not None and datetime.now() > self.bsm_stopTime:
+                        print('Camera stopped because of bsm stop time')
                         self.disable_video()
                     if self.showVideo:
                         capture = self.camera.capture_preview()

--- a/api/cameracontrol.py
+++ b/api/cameracontrol.py
@@ -146,7 +146,7 @@ class CameraControl:
         else:
             self.args.bsm = args.bsm
             try:
-                if not self.showVideo:
+                if not self.showVideo and not args.bsmx:
                     self.showVideo = True
                     self.connect_to_camera()
                     self.socket.send_string('Starting Video')
@@ -328,6 +328,8 @@ def main():
                         for that image, but no video will be created')
     parser.add_argument('-b', '--bsm', action='store_true', help='start preview, but quit preview after taking an \
                         image and wait for message to start preview again', dest='bsm')
+    parser.add_argument('--bsmx', action='store_true', help='prevent cameracontrol.py from restarting the video \
+                        in bsm mode. Useful to just execute a command', dest='bsmx')
     parser.add_argument('-v', '--video', default=None, type=str, dest='video_path',
                         help='save the next part of the preview as a video file')
     parser.add_argument('--vframes', default=4, type=int, help='saves shots from the video in an equidistant time',
@@ -343,7 +345,7 @@ def main():
                         help='chroma key sensitivity (value from 0.01 to 1.0 or 0.0 to disable). \
                              If this is set to a value distinct from 0.0 on capture image command chroma keying using \
                              ffmpeg is applied on the image and only this modified image is stored on the pc. \
-                             If this is set on a preview command you get actual live chroma keying.',
+                             If this is set on a preview command you get actual live chroma keying',
                         dest='chroma_sensitivity')
     parser.add_argument('--chromaBlend', type=float, help='chroma key blend (0.0 to 1.0)', dest='chroma_blend')
     parser.add_argument('--exit', action='store_true', help='exit the service')

--- a/api/cameracontrol.py
+++ b/api/cameracontrol.py
@@ -344,9 +344,9 @@ def main():
                         for that image, but no video will be created')
     parser.add_argument('-b', '--bsm', action='store_true', help='start preview, but quit preview after taking an \
                         image and wait for message to start preview again', dest='bsm')
-    parser.add_argument('--bsmx', action='store_true', help='In bsm mode: prevent cameracontrol.py from restarting\
+    parser.add_argument('--bsmx', action='store_true', help='In bsm mode: prevent cameracontrol.py from restarting \
                         the video. Useful to just execute a command', dest='bsmx')
-    parser.add_argument('--bsmtime', default=0, type=int, help='In bsm mode: keep preview active for the specified\
+    parser.add_argument('--bsmtime', default=0, type=int, help='Keep preview active for the specified \
                         time in minutes before ending the preview video. Set to 0 to disable', dest='bsm_timeOut')
     parser.add_argument('-v', '--video', default=None, type=str, dest='video_path',
                         help='save the next part of the preview as a video file')

--- a/faq/faq.md
+++ b/faq/faq.md
@@ -510,6 +510,14 @@ There's no need to define the _"Command to kill live preview"_ while using the _
 If you want to use the DSLR view as background video, enable _"Use stream for live preview as background"_ and disable the _"Execute start command for preview on take picture/collage"_ setting of Photobooth, which is enabled by default.
 
 
+If you're worried about the sensor of your DSLR but still want to use background video you can use `--bsmtime`.
+
+```sh
+python3 cameracontrol.py --bsmtime 1
+```
+With the parameter `--bsmtime` you can define a number of minutes after which the camera preview ends. Please note the last image of the preview stays for a few seconds before the background turns to black. Additionally you should add `python3 cameracontrol.py` to the *pre-photo command* to restart the preview if it got disabled by the timeout. Restarting the preview takes a few seconds.
+
+
 If you don't want to use the DSLR view as background video enable the _Execute start command for preview on take picture/collage_ setting of Photobooth and make sure `--bsm` was added to the preview command.
 
 ```sh

--- a/src/js/preview.js
+++ b/src/js/preview.js
@@ -95,8 +95,7 @@ const photoboothPreview = (function () {
     };
 
     api.getAndDisplayMedia = function (mode) {
-        console.log(api.stream)
-        if (api.stream) {
+        if (api.stream && api.stream.active) {
             api.changeVideoMode(mode);
         } else {
             api.initializeMedia(() => {

--- a/src/js/preview.js
+++ b/src/js/preview.js
@@ -95,6 +95,7 @@ const photoboothPreview = (function () {
     };
 
     api.getAndDisplayMedia = function (mode) {
+        console.log(api.stream)
         if (api.stream) {
             api.changeVideoMode(mode);
         } else {


### PR DESCRIPTION
<!--
    Thank you for contributing!
-->

#### Prerequisites checklist

- [ ] I have read the [contributing guidelines](https://github.com/PhotoboothProject/photobooth/blob/dev/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "x" next to an item)
<!-- Example:
- [x] Bug fix
-->

- [ ] Documentation update
- [ ] Bug fix
- [X] New feature
- [ ] Other, please explain:

<!--
    Please ensure your pull request is ready:

    - Please run 'yarn build' before submitting to have consistent formatting for both JavaScript & SCSS
    - Please run 'yarn eslint' to make sure there's no lint issues
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)
Added options to cameracontrol.py
--bsmx to execute a command without changing the video state in bsm mode
--bsmtime (number) to stop the preview video after a defined number of minutes

If preview video gets disabled because of the bsmtime currently the next image is taken without any preview. Easiest fix would be to make it possible to have a preview command run at startup and when an image is going to be taken. cameracontrol.py would be fine with that even if the preview video was already active.

#### Is there anything you'd like reviewers to focus on?
