### PR TITLE
fix parsererror on collage with rotated images

### DIFF
--- a/lib/image.php
+++ b/lib/image.php
@@ -460,10 +460,11 @@ class Image {
                     throw new Exception('Cannot rotate image.');
                 }
             } else {
+                $bg_color = $this->resizeBgColor;
                 if (strlen($bg_color) === 7) {
                     $bg_color .= '00';
                 }
-                list($bg_r, $bg_g, $bg_b, $bg_a) = sscanf($this->resizeBgColor, '#%02x%02x%02x%02x');
+                list($bg_r, $bg_g, $bg_b, $bg_a) = sscanf($bg_color, '#%02x%02x%02x%02x');
 
                 // get old dimensions
                 $old_width = imagesx($image);

--- a/lib/image.php
+++ b/lib/image.php
@@ -905,8 +905,8 @@ class Image {
                 $this->resizeRotation = $degrees;
                 $imageResource = self::rotateResizeImage($imageResource);
                 if (abs($degrees) != 90) {
-                    $width = intval(imagesx($imageResource));
-                    $height = intval(imagesy($imageResource));
+                    $width = imagesx($imageResource);
+                    $height = imagesy($imageResource);
                 }
             }
 


### PR DESCRIPTION
<!--
    Thank you for contributing!
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/PhotoboothProject/photobooth/blob/dev/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "x" next to an item)
<!-- Example:
- [x] Bug fix
-->

- [ ] Documentation update
- [x] Bug fix
- [ ] New feature
- [ ] Other, please explain:

<!--
    Please ensure your pull request is ready:

    - Please run 'yarn build' before submitting to have consistent formatting for both JavaScript & SCSS
    - Please run 'yarn eslint' to make sure there's no lint issues
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)
Background color was never defined on rotated resize and throwing an parsererror.

#### Is there anything you'd like reviewers to focus on?
