### PR TITLE
template: adjust manifest to start in fullscreen instead of standalone

### DIFF
--- a/resources/img/site.webmanifest
+++ b/resources/img/site.webmanifest
@@ -15,6 +15,6 @@
     ],
     "theme_color": "#ffffff",
     "background_color": "#ffffff",
-    "display": "standalone",
+    "display": "fullscreen",
     "orientation": "landscape"
 }


### PR DESCRIPTION
#### What is the purpose of this pull request? (put an "x" next to an item)

- [ ] Documentation update
- [ ] Bug fix
- [ ] New feature
- [x] Other, please explain:

#### What changes did you make? (Give an overview)

To behave more like a native app when the app is pinned to the start screen on modern browsers, the default value for the startup is now changed to "fullscreen" instead of "standalone".

See: https://developer.mozilla.org/en-US/docs/Web/Manifest/display
