### PR TITLE
task: replace legacy phpqrcode with endroid/qr-code

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,8 +1,4 @@
 [submodule "vendor/Seriously"]
 	path = vendor/Seriously
 	url = https://github.com/brianchirls/Seriously.js
-    ignore = dirty
-[submodule "vendor/phpqrcode"]
-	path = vendor/phpqrcode
-	url = https://github.com/PhotoboothProject/phpqrcode
-    ignore = dirty
+	ignore = dirty

--- a/api/print.php
+++ b/api/print.php
@@ -83,7 +83,7 @@ if (!file_exists($filename_print)) {
             }
         }
 
-        if ($config['print']['qrcode'] && $imageHandler->qrAvailable) {
+        if ($config['print']['qrcode']) {
             // create qr code
             if ($config['ftp']['enabled'] && $config['ftp']['useForQr']) {
                 $imageHandler->qrUrl = $config['ftp']['processedTemplate'] . DIRECTORY_SEPARATOR . $filename;
@@ -92,7 +92,6 @@ if (!file_exists($filename_print)) {
             } else {
                 $imageHandler->qrUrl = $config['qr']['url'];
             }
-            $imageHandler->qrEcLevel = $config['qr']['ecLevel'];
             $imageHandler->qrSize = $config['print']['qrSize'];
             $imageHandler->qrMargin = $config['print']['qrMargin'];
             $imageHandler->qrColor = $config['print']['qrBgColor'];

--- a/api/qrcode.php
+++ b/api/qrcode.php
@@ -1,5 +1,7 @@
 <?php
 
+use Photobooth\Utility\QrCodeUtility;
+
 require_once '../lib/boot.php';
 
 $filename = (isset($_GET['filename']) && $_GET['filename']) != '' ? $_GET['filename'] : false;
@@ -13,25 +15,9 @@ if ($filename || !$config['qr']['append_filename']) {
         $url = $config['qr']['url'];
     }
     try {
-        switch ($config['qr']['ecLevel']) {
-            case 'QR_ECLEVEL_L':
-                $ecLevel = QR_ECLEVEL_L;
-                break;
-            case 'QR_ECLEVEL_M':
-                $ecLevel = QR_ECLEVEL_M;
-                break;
-            case 'QR_ECLEVEL_Q':
-                $ecLevel = QR_ECLEVEL_Q;
-                break;
-            case 'QR_ECLEVEL_H':
-                $ecLevel = QR_ECLEVEL_H;
-                break;
-            default:
-                $ecLevel = QR_ECLEVEL_M;
-                break;
-        }
-
-        QRcode::png($url, false, $ecLevel, 8);
+        $result = QrCodeUtility::create($url);
+        header('Content-Type: ' . $result->getMimeType());
+        echo $result->getString();
     } catch (Exception $e) {
         http_response_code(500);
         echo 'Error generating QR Code.';

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,10 @@
     "license": "MIT",
     "require": {
         "php": "^8.2",
-        "phpmailer/phpmailer": "^6.8"
+        "ext-gd": "*",
+        "ext-zip": "*",
+        "phpmailer/phpmailer": "^6.8",
+        "endroid/qr-code": "^4.8"
     },
     "autoload": {
         "psr-4": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,187 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "737a11b98cd7719ed8b1b0005b89cc1b",
+    "content-hash": "476a4b112bb45fd44994659d722810ad",
     "packages": [
+        {
+            "name": "bacon/bacon-qr-code",
+            "version": "2.0.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Bacon/BaconQrCode.git",
+                "reference": "8674e51bb65af933a5ffaf1c308a660387c35c22"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Bacon/BaconQrCode/zipball/8674e51bb65af933a5ffaf1c308a660387c35c22",
+                "reference": "8674e51bb65af933a5ffaf1c308a660387c35c22",
+                "shasum": ""
+            },
+            "require": {
+                "dasprid/enum": "^1.0.3",
+                "ext-iconv": "*",
+                "php": "^7.1 || ^8.0"
+            },
+            "require-dev": {
+                "phly/keep-a-changelog": "^2.1",
+                "phpunit/phpunit": "^7 | ^8 | ^9",
+                "spatie/phpunit-snapshot-assertions": "^4.2.9",
+                "squizlabs/php_codesniffer": "^3.4"
+            },
+            "suggest": {
+                "ext-imagick": "to generate QR code images"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "BaconQrCode\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-2-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Ben Scholzen 'DASPRiD'",
+                    "email": "mail@dasprids.de",
+                    "homepage": "https://dasprids.de/",
+                    "role": "Developer"
+                }
+            ],
+            "description": "BaconQrCode is a QR code generator for PHP.",
+            "homepage": "https://github.com/Bacon/BaconQrCode",
+            "support": {
+                "issues": "https://github.com/Bacon/BaconQrCode/issues",
+                "source": "https://github.com/Bacon/BaconQrCode/tree/2.0.8"
+            },
+            "time": "2022-12-07T17:46:57+00:00"
+        },
+        {
+            "name": "dasprid/enum",
+            "version": "1.0.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/DASPRiD/Enum.git",
+                "reference": "6faf451159fb8ba4126b925ed2d78acfce0dc016"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/DASPRiD/Enum/zipball/6faf451159fb8ba4126b925ed2d78acfce0dc016",
+                "reference": "6faf451159fb8ba4126b925ed2d78acfce0dc016",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1 <9.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^7 | ^8 | ^9",
+                "squizlabs/php_codesniffer": "*"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "DASPRiD\\Enum\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-2-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Ben Scholzen 'DASPRiD'",
+                    "email": "mail@dasprids.de",
+                    "homepage": "https://dasprids.de/",
+                    "role": "Developer"
+                }
+            ],
+            "description": "PHP 7.1 enum implementation",
+            "keywords": [
+                "enum",
+                "map"
+            ],
+            "support": {
+                "issues": "https://github.com/DASPRiD/Enum/issues",
+                "source": "https://github.com/DASPRiD/Enum/tree/1.0.5"
+            },
+            "time": "2023-08-25T16:18:39+00:00"
+        },
+        {
+            "name": "endroid/qr-code",
+            "version": "4.8.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/endroid/qr-code.git",
+                "reference": "a122b85d4a5a3257d471257a43ac3e5676a27ffe"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/endroid/qr-code/zipball/a122b85d4a5a3257d471257a43ac3e5676a27ffe",
+                "reference": "a122b85d4a5a3257d471257a43ac3e5676a27ffe",
+                "shasum": ""
+            },
+            "require": {
+                "bacon/bacon-qr-code": "^2.0.5",
+                "php": "^8.1"
+            },
+            "conflict": {
+                "khanamiryan/qrcode-detector-decoder": "^1.0.6"
+            },
+            "require-dev": {
+                "endroid/quality": "dev-master",
+                "ext-gd": "*",
+                "khanamiryan/qrcode-detector-decoder": "^1.0.4||^2.0.2",
+                "setasign/fpdf": "^1.8.2"
+            },
+            "suggest": {
+                "ext-gd": "Enables you to write PNG images",
+                "khanamiryan/qrcode-detector-decoder": "Enables you to use the image validator",
+                "roave/security-advisories": "Makes sure package versions with known security issues are not installed",
+                "setasign/fpdf": "Enables you to use the PDF writer"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Endroid\\QrCode\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jeroen van den Enden",
+                    "email": "info@endroid.nl"
+                }
+            ],
+            "description": "Endroid QR Code",
+            "homepage": "https://github.com/endroid/qr-code",
+            "keywords": [
+                "code",
+                "endroid",
+                "php",
+                "qr",
+                "qrcode"
+            ],
+            "support": {
+                "issues": "https://github.com/endroid/qr-code/issues",
+                "source": "https://github.com/endroid/qr-code/tree/4.8.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/endroid",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-08-28T18:12:07+00:00"
+        },
         {
             "name": "phpmailer/phpmailer",
             "version": "v6.8.1",
@@ -94,7 +273,9 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": "^8.2"
+        "php": "^8.2",
+        "ext-gd": "*",
+        "ext-zip": "*"
     },
     "platform-dev": [],
     "plugin-api-version": "2.6.0"

--- a/config/config.inc.php
+++ b/config/config.inc.php
@@ -259,7 +259,6 @@ $config['textonprint']['linespace'] = '100';
 
 // Q R  -  C O D E
 $config['qr']['enabled'] = true;
-$config['qr']['ecLevel'] = 'QR_ECLEVEL_M';
 $config['qr']['url'] = '';
 $config['qr']['append_filename'] = true;
 $config['qr']['custom_text'] = false;

--- a/install-photobooth.sh
+++ b/install-photobooth.sh
@@ -39,7 +39,6 @@ PHOTOBOOTH_PATH=(
         '/var/www/html/photobooth'
 )
 PHOTOBOOTH_SUBMODULES=(
-        'vendor/phpqrcode'
         'vendor/rpihotspot'
         'vendor/Seriously'
 )

--- a/lib/boot.php
+++ b/lib/boot.php
@@ -4,7 +4,6 @@ session_start();
 
 // Autoload
 require_once dirname(__DIR__) . '/vendor/autoload.php';
-require_once dirname(__DIR__) . '/vendor/phpqrcode/lib/full/qrlib.php';
 
 // Config
 require_once dirname(__DIR__) . '/lib/config.php';

--- a/lib/configsetup.inc.php
+++ b/lib/configsetup.inc.php
@@ -1727,18 +1727,6 @@ $configsetup = [
             'name' => 'qr[enabled]',
             'value' => $config['qr']['enabled'],
         ],
-        'qr_ecLevel' => [
-            'type' => 'select',
-            'name' => 'qr[ecLevel]',
-            'placeholder' => $defaultConfig['qr']['ecLevel'],
-            'options' => [
-                'QR_ECLEVEL_L' => 'L - smallest',
-                'QR_ECLEVEL_M' => 'M',
-                'QR_ECLEVEL_Q' => 'Q',
-                'QR_ECLEVEL_H' => 'H - best',
-            ],
-            'value' => $config['qr']['ecLevel'],
-        ],
         'qr_url' => [
             'view' => 'expert',
             'type' => 'input',

--- a/lib/src/Utility/QrCodeUtility.php
+++ b/lib/src/Utility/QrCodeUtility.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Photobooth\Utility;
+
+use Endroid\QrCode\Builder\Builder;
+use Endroid\QrCode\Encoding\Encoding;
+use Endroid\QrCode\ErrorCorrectionLevel\ErrorCorrectionLevelMedium;
+use Endroid\QrCode\Label\Margin\Margin;
+use Endroid\QrCode\RoundBlockSizeMode\RoundBlockSizeModeMargin;
+use Endroid\QrCode\Writer\PngWriter;
+use Endroid\QrCode\Writer\Result\ResultInterface;
+
+class QrCodeUtility
+{
+    public static function create(string $text, string $labelText = '', int $size = 300, int $margin = 15): ResultInterface
+    {
+        $builder = Builder::create()
+            ->writer(new PngWriter())
+            ->writerOptions([])
+            ->data($text)
+            ->encoding(new Encoding('UTF-8'))
+            ->errorCorrectionLevel(new ErrorCorrectionLevelMedium())
+            ->size($size - (2 * $margin))
+            ->margin($margin)
+            ->roundBlockSizeMode(new RoundBlockSizeModeMargin());
+
+        if ($labelText !== '') {
+            $builder
+                ->labelText($labelText)
+                ->labelMargin(new Margin(0, $margin, $margin, $margin));
+        }
+
+        $result = $builder
+            ->validateResult(false)
+            ->build();
+
+        return $result;
+    }
+}


### PR DESCRIPTION
The current phpqrcode does not support PSR-4 autoloading
and is not namespaced. We are switching to endroid/qr-code
to ease the generation of creating qrcodes. The dependency
is now managed via composer.

The current phpqrcode does not support PSR-4 autoloading
and is not namespaced. We are switching to endroid/qr-code
to ease the generation of creating QR codes.

We are dropping the config error correction level from the
configuration, this is too advanced for general users and
without deep knowledge of QR codes the levels are chosen
by looks and not by its usefulness.

The error correction level describes how damaged a
QR code can be before it is not readable anymore. Since
we are using screens/printouts, we do not expect a
high damage rate like on packaging materials.

The error correction is now by default medium (~15%).