### PR TITLE
task: streamline path handling

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -10,7 +10,10 @@ end_of_line = lf
 insert_final_newline = true
 trim_trailing_whitespace = true
 
-# PHP-Files
+[*.html]
+indent_style = space
+indent_size = 4
+
 [*.php]
 indent_style = space
 indent_size = 4

--- a/admin/components/content.php
+++ b/admin/components/content.php
@@ -1,9 +1,14 @@
+<?php
+
+use Photobooth\Utility\PathUtility;
+
+?>
 <form class="w-full h-full flex flex-col" autocomplete="off">
     <div class="adminContent w-full flex flex-1 flex-col py-5 overflow-x-hidden overflow-y-auto">
-        <?php include('_getSettings.php'); ?>
+        <?php include PathUtility::getAbsolutePath('admin/components/_getSettings.php'); ?>
     </div>
 
-    <div class="pt-5 pb-5 mx-4 lg:mx-8">  
+    <div class="pt-5 pb-5 mx-4 lg:mx-8">
         <div class="w-44 ml-auto">
             <?php echo getCtaBtn('save', 'save-admin-btn'); ?>
         </div>

--- a/admin/components/footer.admin.php
+++ b/admin/components/footer.admin.php
@@ -1,3 +1,8 @@
+<?php
+
+use Photobooth\Utility\PathUtility;
+
+?>
     <div class="pageLoader w-full h-full fixed top-0 left-0 z-50 hidden place-items-center [&.isActive]:grid">
         <div class="w-full h-full left-0 top-0 z-10 absolute bg-black bg-opacity-60"></div>
         <div class="min-w-[115px] px-4 py-6 rounded-md bg-white shadow-md flex flex-col items-center justify-center relative z-20 text-center">
@@ -8,11 +13,10 @@
 
     <?php echo getToast(); ?>
 
-    <script src="<?=$fileRoot?>node_modules/whatwg-fetch/dist/fetch.umd.js"></script>
-    <script type="text/javascript" src="<?=$fileRoot?>api/config.php?v=<?php echo $config['photobooth']['version']; ?>"></script>
-    <script src="<?=$fileRoot?>node_modules/@andreasremdt/simple-translator/dist/umd/translator.min.js"></script>
-    <script type="text/javascript" src="<?=$fileRoot?>resources/js/i18n.js?v=<?=$config['photobooth']['version']?>"></script>
-
-    <script type="text/javascript" src="<?=$fileRoot?>resources/js/main.admin.js?v=<?php echo $config['photobooth']['version']; ?>"></script>
+    <script type="text/javascript" src="<?=PathUtility::getPublicPath()?>node_modules/whatwg-fetch/dist/fetch.umd.js"></script>
+    <script type="text/javascript" src="<?=PathUtility::getPublicPath()?>api/config.php?v=<?php echo $config['photobooth']['version']; ?>"></script>
+    <script type="text/javascript" src="<?=PathUtility::getPublicPath()?>node_modules/@andreasremdt/simple-translator/dist/umd/translator.min.js"></script>
+    <script type="text/javascript" src="<?=PathUtility::getPublicPath()?>resources/js/i18n.js?v=<?=$config['photobooth']['version']?>"></script>
+    <script type="text/javascript" src="<?=PathUtility::getPublicPath()?>resources/js/main.admin.js?v=<?php echo $config['photobooth']['version']; ?>"></script>
  </body>
 </html>

--- a/admin/components/head.admin.php
+++ b/admin/components/head.admin.php
@@ -1,33 +1,38 @@
+<?php
+
+use Photobooth\Utility\PathUtility;
+
+?>
 <!DOCTYPE html>
 <html>
 <head>
-        <meta charset="UTF-8" />
-        <meta name="viewport" content="width=device-width, initial-scale=1.0 user-scalable=no">
-        <meta name="msapplication-TileColor" content="<?=$config['colors']['primary']?>">
-        <meta name="theme-color" content="<?=$config['colors']['primary']?>">
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0 user-scalable=no">
+    <meta name="msapplication-TileColor" content="<?=$config['colors']['primary']?>">
+    <meta name="theme-color" content="<?=$config['colors']['primary']?>">
 
-        <title><?=$pageTitle ?></title>
+    <title><?=$pageTitle ?></title>
 
-        <!-- Favicon + Android/iPhone Icons -->
-        <link rel="apple-touch-icon" sizes="180x180" href="<?=$fileRoot?>resources/img/apple-touch-icon.png">
-        <link rel="icon" type="image/png" sizes="32x32" href="<?=$fileRoot?>resources/img/favicon-32x32.png">
-        <link rel="icon" type="image/png" sizes="16x16" href="<?=$fileRoot?>resources/img/favicon-16x16.png">
-        <link rel="manifest" href="<?=$fileRoot?>resources/img/site.webmanifest">
-        <link rel="mask-icon" href="<?=$fileRoot?>resources/img/safari-pinned-tab.svg" color="#5bbad5">
+    <!-- Favicon + Android/iPhone Icons -->
+    <link rel="apple-touch-icon" sizes="180x180" href="<?=PathUtility::getPublicPath()?>resources/img/apple-touch-icon.png">
+    <link rel="icon" type="image/png" sizes="32x32" href="<?=PathUtility::getPublicPath()?>resources/img/favicon-32x32.png">
+    <link rel="icon" type="image/png" sizes="16x16" href="<?=PathUtility::getPublicPath()?>resources/img/favicon-16x16.png">
+    <link rel="manifest" href="<?=PathUtility::getPublicPath()?>resources/img/site.webmanifest">
+    <link rel="mask-icon" href="<?=PathUtility::getPublicPath()?>resources/img/safari-pinned-tab.svg" color="#5bbad5">
 
-        <!-- tw admin -->
-        <link rel="stylesheet" href="<?=$fileRoot?>resources/css/tailwind.admin.css"/>
+    <!-- tw admin -->
+    <link rel="stylesheet" href="<?=PathUtility::getPublicPath()?>resources/css/tailwind.admin.css"/>
 
-        <?php if (is_file($fileRoot . 'private/overrides.css')): ?>
-        <link rel="stylesheet" href="<?=$fileRoot?>private/overrides.css?v=<?php echo $config['photobooth']['version']; ?>" />
-        <?php endif; ?>
-        <!-- js -->
-        <script type="text/javascript" src="<?=$fileRoot?>node_modules/jquery/dist/jquery.min.js"></script>
-<style>
-:root {
-    --brand-1: <?=$config['colors']['panel'];?>;
-    --brand-2: <?=$config['colors']['primary_light'];?>;
-}
-</style>
-</head> 
+    <?php if (is_file(PathUtility::getPublicPath() . 'private/overrides.css')): ?>
+    <link rel="stylesheet" href="<?=PathUtility::getPublicPath()?>private/overrides.css?v=<?php echo $config['photobooth']['version']; ?>" />
+    <?php endif; ?>
+    <!-- js -->
+    <script type="text/javascript" src="<?=PathUtility::getPublicPath()?>node_modules/jquery/dist/jquery.min.js"></script>
+        <style>
+        :root {
+            --brand-1: <?=$config['colors']['panel'];?>;
+            --brand-2: <?=$config['colors']['primary_light'];?>;
+        }
+    </style>
+</head>
 <body class="w-full h-screen overflow-hidden fixed">

--- a/admin/components/sidebar.php
+++ b/admin/components/sidebar.php
@@ -1,5 +1,8 @@
 <?php
-include('navItem.php');
+
+use Photobooth\Utility\PathUtility;
+
+include PathUtility::getAbsolutePath('admin/components/navItem.php');
 
 $headline = 'Sidebar';
 if (isset($sidebarHeadline)) {
@@ -24,7 +27,7 @@ if (isset($sidebarHeadline)) {
 <div class="adminNavi hidden [&.isActive]:flex z-50 bg-brand-1 h-full pb-10 overflow-hidden w-3/4 fixed top-0 right-0 md:w-64 md:flex md:static md:bg-transparent">
     <div class="w-full h-full pl-5 flex flex-col overflow-hidden">
         <div class="flex items-center shrink-0 border-b border-solid border-white border-opacity-20 py-4 mr-4">
-            <a href="<?=$fileRoot?>login" class="h-4 mr-4 flex items-center justify-center border-r border-solid border-white border-opacity-20 px-3">
+            <a href="<?=PathUtility::getPublicPath('login')?>" class="h-4 mr-4 flex items-center justify-center border-r border-solid border-white border-opacity-20 px-3">
                 <span class="fa fa-home text-white text-opacity-60 text-2xl hover:text-opacity-100 transition-all"></span>
             </a>
             <h1 class="text-white font-bold"><?=$headline ?></h1>

--- a/admin/debug/index.php
+++ b/admin/debug/index.php
@@ -1,34 +1,34 @@
 <?php
+
 require_once '../../lib/boot.php';
 
 use Photobooth\Environment;
+use Photobooth\Utility\PathUtility;
 
 // Login / Authentication check
-if (
+if (!(
     !$config['login']['enabled'] ||
-    (!$config['protect']['localhost_admin'] && $_SERVER['REMOTE_ADDR'] === $_SERVER['SERVER_ADDR']) ||
-    (isset($_SESSION['auth']) && $_SESSION['auth'] === true) ||
-    !$config['protect']['admin']
-) {
-    require_once '../../lib/configsetup.inc.php';
-} else {
-    header('location: ../../login');
+    (!$config['protect']['localhost_admin'] && isset($_SERVER['SERVER_ADDR']) &&  $_SERVER['REMOTE_ADDR'] === $_SERVER['SERVER_ADDR']) ||
+    (isset($_SESSION['auth']) && $_SESSION['auth'] === true) || !$config['protect']['admin']
+)) {
+    header('location: ' . PathUtility::getPublicPath('login'));
     exit();
 }
 
-$fileRoot = '../../';
+require_once PathUtility::getAbsolutePath('lib/configsetup.inc.php');
+
 $pageTitle = 'Debugpanel';
-include('../../admin/components/head.admin.php');
-include('../../admin/helper/index.php');
-include('../../admin/inputs/index.php');
-include('../../admin/components/navItem.debug.php');
+include PathUtility::getAbsolutePath('admin/components/head.admin.php');
+include PathUtility::getAbsolutePath('admin/helper/index.php');
+include PathUtility::getAbsolutePath('admin/inputs/index.php');
+include PathUtility::getAbsolutePath('admin/components/navItem.debug.php');
 ?>
     <div class="w-full h-full flex flex-col bg-brand-1 overflow-hidden fixed top-0 left-0">
-		<div class="max-w-[2000px] mx-auto w-full h-full flex flex-col">
+        <div class="max-w-[2000px] mx-auto w-full h-full flex flex-col">
 
 
-			<!-- body -->
-			<div class="w-full h-full flex flex-1 flex-col md:flex-row mt-5 overflow-hidden">
+            <!-- body -->
+            <div class="w-full h-full flex flex-1 flex-col md:flex-row mt-5 overflow-hidden">
                 <div class="w-full flex md:hidden px-5 pb-5 items-center">
                     <div class="w-full flex flex-col">
                         <span class="text-2xl text-white">Debugpanel</span>
@@ -42,7 +42,7 @@ include('../../admin/components/navItem.debug.php');
                 <div class="adminNavi hidden [&.isActive]:flex z-50 bg-brand-1 h-full pb-10 overflow-hidden w-3/4 fixed top-0 right-0 md:w-64 md:flex md:static md:bg-transparent">
                     <div class="w-full h-full pl-5 flex flex-col overflow-hidden">
                         <div class="flex items-center shrink-0 border-b border-solid border-white border-opacity-20 py-4 mr-4">
-                            <a href="<?=$fileRoot?>admin" class="h-4 mr-4 flex items-center justify-center border-r border-solid border-white border-opacity-20 px-3">
+                            <a href="<?=PathUtility::getPublicPath('admin')?>" class="h-4 mr-4 flex items-center justify-center border-r border-solid border-white border-opacity-20 px-3">
                                 <span class="fa fa-chevron-left text-white text-opacity-60 text-md hover:text-opacity-100 transition-all"></span>
                             </a>
                             <h1 class="text-white font-bold">Debugpanel</h1>
@@ -71,10 +71,10 @@ echo getNavItemDebug('githead');
                     </div>
                 </div>
                 </div>
-				<div class="flex flex-1 flex-col bg-content-1 rounded-xl ml-5 mr-5 mb-5 md:ml-0 overflow-hidden">
+                <div class="flex flex-1 flex-col bg-content-1 rounded-xl ml-5 mr-5 mb-5 md:ml-0 overflow-hidden">
 
-					<div class="w-full h-full flex flex-col" autocomplete="off">
-						<div class="adminContent w-full flex flex-1 flex-col py-5 overflow-x-hidden overflow-y-auto">
+                    <div class="w-full h-full flex flex-col" autocomplete="off">
+                        <div class="adminContent w-full flex flex-1 flex-col py-5 overflow-x-hidden overflow-y-auto">
                             <div class="debugcontent py-2 px-5"></div>
                         </div>
                         <div class="w-full flex px-5 py-3 border-t border-solid border-gray-300">
@@ -106,8 +106,8 @@ echo getNavItemDebug('githead');
 </div>
 
 
-<script type="text/javascript" src="<?=$fileRoot?>resources/js/tools.js?v=<?php echo $config['photobooth']['version']; ?>"></script>
-<script type="text/javascript" src="<?=$fileRoot?>resources/js/debugpanel.js?v=<?php echo $config['photobooth']['version']; ?>"></script>
+<script type="text/javascript" src="<?=PathUtility::getPublicPath()?>resources/js/tools.js?v=<?php echo $config['photobooth']['version']; ?>"></script>
+<script type="text/javascript" src="<?=PathUtility::getPublicPath()?>resources/js/debugpanel.js?v=<?php echo $config['photobooth']['version']; ?>"></script>
 
 <?php
-    include('../components/footer.admin.php');
+    include PathUtility::getAbsolutePath('admin/components/footer.admin.php');

--- a/admin/diskusage/index.php
+++ b/admin/diskusage/index.php
@@ -1,68 +1,65 @@
 <?php
+
 require_once '../../lib/boot.php';
 
 use Photobooth\Helper;
+use Photobooth\Utility\PathUtility;
 
 // Login / Authentication check
-if (
-    $config['login']['enabled'] ||
-    ($config['protect']['localhost_admin'] && $_SERVER['REMOTE_ADDR'] !== $_SERVER['SERVER_ADDR']) ||
-    !isset($_SESSION['auth']) ||
-    $_SESSION['auth'] !== true ||
-    $config['protect']['admin']
-) {
-    header('location: ../../login');
+if (!(
+    !$config['login']['enabled'] ||
+    (!$config['protect']['localhost_admin'] && isset($_SERVER['SERVER_ADDR']) &&  $_SERVER['REMOTE_ADDR'] === $_SERVER['SERVER_ADDR']) ||
+    (isset($_SESSION['auth']) && $_SESSION['auth'] === true) || !$config['protect']['admin']
+)) {
+    header('location: ' . PathUtility::getPublicPath('login'));
     exit();
 }
 
-$fileRoot = '../../';
+require_once PathUtility::getAbsolutePath('lib/configsetup.inc.php');
+
 $pageTitle = 'Diskusage';
-include('../../admin/components/head.admin.php');
-include('../helper/index.php');
-include('../inputs/index.php');
+include PathUtility::getAbsolutePath('admin/components/head.admin.php');
+include PathUtility::getAbsolutePath('admin/helper/index.php');
+include PathUtility::getAbsolutePath('admin/inputs/index.php');
 ?>
-	<div class="w-full h-full grid place-items-center fixed bg-brand-1 overflow-x-hidden overflow-y-auto">
-		<div class="w-full flex items-center justify-center flex-col px-6 py-12">
+<div class="w-full h-full grid place-items-center fixed bg-brand-1 overflow-x-hidden overflow-y-auto">
+    <div class="w-full flex items-center justify-center flex-col px-6 py-12">
 
-			<div class="w-full max-w-xl h-144 rounded-lg p-4 md:p-8 bg-white flex flex-col shadow-xl">
-				<div class="w-full flex items-center pb-3 mb-3 border-b border-solid border-gray-200">
-					<a href="../" class="h-4 mr-4 flex items-center justify-center border-r border-solid border-black border-opacity-20 pr-3">
-						<span class="fa fa-chevron-left text-brand-1 text-opacity-60 text-md hover:text-opacity-100 transition-all"></span>
-					</a>
-					<h2 class="text-brand-1 text-xl font-bold">
-						<?=$config['ui']['branding']?>
-						<span data-i18n="disk_usage"></span>
-					</h2>
-				</div>
-				<?php
-                    foreach ($config['foldersAbs'] as $key => $folder) {
-                        try {
-                            $folderSize = Helper::getFolderSize($folder);
-                            $formattedSize = Helper::formatSize($folderSize);
-                            $fileCount = Helper::getFileCount($folder);
+        <div class="w-full max-w-xl h-144 rounded-lg p-4 md:p-8 bg-white flex flex-col shadow-xl">
+            <div class="w-full flex items-center pb-3 mb-3 border-b border-solid border-gray-200">
+                <a href="<?=PathUtility::getPublicPath('admin')?>" class="h-4 mr-4 flex items-center justify-center border-r border-solid border-black border-opacity-20 pr-3">
+                    <span class="fa fa-chevron-left text-brand-1 text-opacity-60 text-md hover:text-opacity-100 transition-all"></span>
+                </a>
+                <h2 class="text-brand-1 text-xl font-bold">
+                    <?= $config['ui']['branding'] ?>
+                    <span data-i18n="disk_usage"></span>
+                </h2>
+            </div>
+            <?php
+            foreach ($config['foldersAbs'] as $key => $folder) {
+                try {
+                    $folderSize = Helper::getFolderSize($folder);
+                    $formattedSize = Helper::formatSize($folderSize);
+                    $fileCount = Helper::getFileCount($folder);
 
-                            echo '<div class="pb-3 mb-3 border-b border-solid border-gray-200 flex flex-col">';
-                            echo '<h3 class="font-bold whitespace-pre-wrap break-all"><span data-i18n="path"></span> ' . $folder . '</h3>';
-                            echo '<div><span class="flex text-sm mt-2" data-i18n="foldersize"></span></div><span class="text-brand-1">' . $formattedSize . '</span>';
-                            echo '<div><span class="flex text-sm mt-2" data-i18n="filecount"></span></div><span class="text-brand-1">' . $fileCount . '</span>';
-                            echo '</div>';
-                        } catch (Exception $e) {
-                            echo '<div class="pb-3 mb-3 border-b border-solid border-gray-200 flex flex-col">';
-                            echo '<h3 class="font-bold whitespace-pre-wrap break-all"><span data-i18n="path"></span> ' . $folder . '</h3>';
-                            echo '<div><span class="flex text-sm mt-2" data-i18n="foldersize"></span></div><span class="text-brand-1">' . $e->getMessage() . '</span>';
-                            echo '<div><span class="flex text-sm mt-2" data-i18n="filecount"></span></div><span class="text-brand-1">' . $e->getMessage() . '</span>';
-                            echo '</div>';
-                        }
-                    }
+                    echo '<div class="pb-3 mb-3 border-b border-solid border-gray-200 flex flex-col">';
+                    echo '<h3 class="font-bold whitespace-pre-wrap break-all"><span data-i18n="path"></span> ' . $folder . '</h3>';
+                    echo '<div><span class="flex text-sm mt-2" data-i18n="foldersize"></span></div><span class="text-brand-1">' . $formattedSize . '</span>';
+                    echo '<div><span class="flex text-sm mt-2" data-i18n="filecount"></span></div><span class="text-brand-1">' . $fileCount . '</span>';
+                    echo '</div>';
+                } catch (Exception $e) {
+                    echo '<div class="pb-3 mb-3 border-b border-solid border-gray-200 flex flex-col">';
+                    echo '<h3 class="font-bold whitespace-pre-wrap break-all"><span data-i18n="path"></span> ' . $folder . '</h3>';
+                    echo '<div><span class="flex text-sm mt-2" data-i18n="foldersize"></span></div><span class="text-brand-1">' . $e->getMessage() . '</span>';
+                    echo '<div><span class="flex text-sm mt-2" data-i18n="filecount"></span></div><span class="text-brand-1">' . $e->getMessage() . '</span>';
+                    echo '</div>';
+                }
+            }
 ?>
-			</div>
+        </div>
 
-		</div>
-	</div>
-
-
-
+    </div>
+</div>
 
 <?php
-    include('../components/footer.admin.php');
-?>
+    include PathUtility::getAbsolutePath('admin/components/footer.admin.php');

--- a/admin/helper/index.php
+++ b/admin/helper/index.php
@@ -1,8 +1,10 @@
 <?php
 
-include 'loader.php';
-include 'hiddenElement.php';
-include 'indent.php';
-include 'ctaBtn.php';
-include 'menuBtn.php';
-include 'toast.php';
+use Photobooth\Utility\PathUtility;
+
+include PathUtility::getAbsolutePath('admin/helper/loader.php');
+include PathUtility::getAbsolutePath('admin/helper/hiddenElement.php');
+include PathUtility::getAbsolutePath('admin/helper/indent.php');
+include PathUtility::getAbsolutePath('admin/helper/ctaBtn.php');
+include PathUtility::getAbsolutePath('admin/helper/menuBtn.php');
+include PathUtility::getAbsolutePath('admin/helper/toast.php');

--- a/admin/index.php
+++ b/admin/index.php
@@ -1,38 +1,38 @@
 <?php
 
-$fileRoot = '../';
-require_once $fileRoot . 'lib/boot.php';
+require_once '../lib/boot.php';
+
+use Photobooth\Utility\PathUtility;
 
 // Login / Authentication check
-if (
+if (!(
     !$config['login']['enabled'] ||
     (!$config['protect']['localhost_admin'] && isset($_SERVER['SERVER_ADDR']) &&  $_SERVER['REMOTE_ADDR'] === $_SERVER['SERVER_ADDR']) ||
-    (isset($_SESSION['auth']) && $_SESSION['auth'] === true) ||
-    !$config['protect']['admin']
-) {
-    require_once $fileRoot . 'lib/configsetup.inc.php';
-} else {
-    header('location: ' . $fileRoot . 'login');
+    (isset($_SESSION['auth']) && $_SESSION['auth'] === true) || !$config['protect']['admin']
+)) {
+    header('location: ' . PathUtility::getPublicPath('login'));
     exit();
 }
 
+require_once PathUtility::getAbsolutePath('lib/configsetup.inc.php');
+
 $pageTitle = 'Adminpanel';
-include('components/head.admin.php');
-include('helper/index.php');
-include('inputs/index.php');
+include PathUtility::getAbsolutePath('admin/components/head.admin.php');
+include PathUtility::getAbsolutePath('admin/helper/index.php');
+include PathUtility::getAbsolutePath('admin/inputs/index.php');
 ?>
 
     <div class="w-full h-full flex flex-col bg-brand-1 overflow-hidden fixed top-0 left-0">
         <div class="max-w-[2000px] mx-auto w-full h-full flex flex-col overflow-hidden">
-            
+
             <!-- body -->
-			<div class="w-full h-full flex flex-1 flex-col md:flex-row mt-5 overflow-hidden">
+            <div class="w-full h-full flex flex-1 flex-col md:flex-row mt-5 overflow-hidden">
                 <?php
                     $sidebarHeadline = $pageTitle;
-include('components/sidebar.php');
+include PathUtility::getAbsolutePath('admin/components/sidebar.php');
 ?>
-				<div class="flex flex-1 flex-col bg-content-1 rounded-xl ml-5 mr-5 mb-5 md:ml-0 overflow-hidden">
-                    <?php include('components/content.php'); ?>
+                <div class="flex flex-1 flex-col bg-content-1 rounded-xl ml-5 mr-5 mb-5 md:ml-0 overflow-hidden">
+                    <?php include PathUtility::getAbsolutePath('admin/components/content.php'); ?>
                 </div>
             </div>
 
@@ -41,5 +41,4 @@ include('components/sidebar.php');
 
 
 <?php
-    include('components/footer.admin.php');
-?>
+    include PathUtility::getAbsolutePath('admin/components/footer.admin.php');

--- a/admin/inputs/imageSelect.php
+++ b/admin/inputs/imageSelect.php
@@ -1,6 +1,6 @@
 <?php
 
-use Photobooth\Helper;
+use Photobooth\Utility\PathUtility;
 
 function getImageSelect($setting, $i18ntag)
 {
@@ -22,10 +22,10 @@ function getImageSelect($setting, $i18ntag)
             str_contains($value, '.webp') ||
             str_contains($value, '.svg')
         ) {
-            $value = Helper::fixSeperator($value);
+            $value = PathUtility::fixFilePath($value);
             $imgPath = $value;
             $origin = $value;
-            $serverRoot = Helper::fixSeperator($_SERVER['DOCUMENT_ROOT']);
+            $serverRoot = PathUtility::fixFilePath($_SERVER['DOCUMENT_ROOT']);
             if (str_contains($value, $serverRoot)) {
                 $origin = substr($value, strlen($serverRoot));
                 $imgPath = substr($value, strlen($serverRoot));

--- a/admin/inputs/index.php
+++ b/admin/inputs/index.php
@@ -1,10 +1,12 @@
 <?php
 
-include 'checkbox.php';
-include 'colorInput.php';
-include 'inputButton.php';
-include 'headline.php';
-include 'rangeInput.php';
-include 'imageSelect.php';
-include 'select.php';
-include 'textInput.php';
+use Photobooth\Utility\PathUtility;
+
+include PathUtility::getAbsolutePath('admin/inputs/checkbox.php');
+include PathUtility::getAbsolutePath('admin/inputs/colorInput.php');
+include PathUtility::getAbsolutePath('admin/inputs/inputButton.php');
+include PathUtility::getAbsolutePath('admin/inputs/headline.php');
+include PathUtility::getAbsolutePath('admin/inputs/rangeInput.php');
+include PathUtility::getAbsolutePath('admin/inputs/imageSelect.php');
+include PathUtility::getAbsolutePath('admin/inputs/select.php');
+include PathUtility::getAbsolutePath('admin/inputs/textInput.php');

--- a/admin/upload/index.php
+++ b/admin/upload/index.php
@@ -1,24 +1,24 @@
 <?php
 
-$fileRoot = '../../';
-require_once $fileRoot . 'lib/boot.php';
+require_once '../../lib/boot.php';
+
+use Photobooth\Utility\PathUtility;
 
 // Login / Authentication check
-if (
+if (!(
     !$config['login']['enabled'] ||
-    (!$config['protect']['localhost_admin'] && isset($_SERVER['SERVER_ADDR']) && $_SERVER['REMOTE_ADDR'] === $_SERVER['SERVER_ADDR']) ||
-    (isset($_SESSION['auth']) && $_SESSION['auth'] === true) ||
-    !$config['protect']['admin']
-) {
-    // nothing for now
-} else {
-    header('location: ' . $fileRoot . 'login');
+    (!$config['protect']['localhost_admin'] && isset($_SERVER['SERVER_ADDR']) &&  $_SERVER['REMOTE_ADDR'] === $_SERVER['SERVER_ADDR']) ||
+    (isset($_SESSION['auth']) && $_SESSION['auth'] === true) || !$config['protect']['admin']
+)) {
+    header('location: ' . PathUtility::getPublicPath('login'));
     exit();
 }
 
+require_once PathUtility::getAbsolutePath('lib/configsetup.inc.php');
+
 $pageTitle = 'Image uploader';
-include '../components/head.admin.php';
-include '../helper/index.php';
+include PathUtility::getAbsolutePath('admin/components/head.admin.php');
+include PathUtility::getAbsolutePath('admin/helper/index.php');
 
 $error = false;
 $success = false;
@@ -103,10 +103,10 @@ if (isset($_POST['submit'])) {
             <div class="w-full max-w-xl rounded-lg py-8 bg-white flex flex-col shadow-xl relative">
                 <div class="grid grid-cols-1 md:grid-cols-2 gap-4 px-4 ">
                 <?php
-                    echo getMenuBtn($fileRoot . 'admin', 'admin_panel', $config['icons']['admin']);
+                    echo getMenuBtn(PathUtility::getPublicPath('admin'), 'admin_panel', $config['icons']['admin']);
 
 if (isset($_SESSION['auth']) && $_SESSION['auth'] === true) {
-    echo getMenuBtn($fileRoot . 'login/logout.php', 'logout', $config['icons']['logout']);
+    echo getMenuBtn(PathUtility::getPublicPath('login/logout.php'), 'logout', $config['icons']['logout']);
 }
 ?>
                 </div>
@@ -114,8 +114,8 @@ if (isset($_SESSION['auth']) && $_SESSION['auth'] === true) {
         </div>
     </div>
 
-<?php
-    include '../components/footer.admin.php';
+    <?php
+    include PathUtility::getAbsolutePath('admin/components/footer.admin.php');
 
 if ($success) {
     echo '<script>openToast("<span data-i18n=\"upload_success\"></span>");</script>';

--- a/api/admin.php
+++ b/api/admin.php
@@ -6,6 +6,7 @@ use Photobooth\Helper;
 use Photobooth\DataLogger;
 use Photobooth\PrintManager;
 use Photobooth\Environment;
+use Photobooth\Utility\PathUtility;
 
 header('Content-Type: application/json');
 
@@ -196,67 +197,37 @@ if (isset($data['type'])) {
         }
     }
 
-    if ($newConfig['picture']['take_frame']) {
-        if (
-            empty($newConfig['picture']['frame']) ||
-            !is_array(
-                @getimagesize(str_starts_with($newConfig['picture']['frame'], 'http') ? $newConfig['picture']['frame'] : $_SERVER['DOCUMENT_ROOT'] . $newConfig['picture']['frame'])
-            )
-        ) {
-            $newConfig['picture']['take_frame'] = false;
-            $Logger->addLogData(['frame' => 'Picture frame does not exist or is empty. Picture frame disabled.']);
-            $Logger->addLogData(['frame' => empty($newConfig['picture']['frame']) ? 'Empty.' : $newConfig['picture']['frame']]);
-        }
+    if ($newConfig['picture']['take_frame'] && $newConfig['picture']['frame'] === '') {
+        $newConfig['picture']['take_frame'] = false;
+        $Logger->addLogData(['frame' => empty($newConfig['picture']['frame']) ? 'Empty.' : $newConfig['picture']['frame']]);
     }
 
-    if ($newConfig['collage']['take_frame']) {
-        if (
-            empty($newConfig['collage']['frame']) ||
-            !is_array(
-                @getimagesize(str_starts_with($newConfig['collage']['frame'], 'http') ? $newConfig['collage']['frame'] : $_SERVER['DOCUMENT_ROOT'] . $newConfig['collage']['frame'])
-            )
-        ) {
-            $newConfig['collage']['take_frame'] = false;
-            $Logger->addLogData(['frame' => 'Collage frame does not exist or is empty. Collage frame disabled.']);
-            $Logger->addLogData(['frame' => empty($newConfig['collage']['frame']) ? 'Empty.' : $newConfig['collage']['frame']]);
-        }
+    if ($newConfig['collage']['take_frame'] && $newConfig['collage']['frame'] === '') {
+        $newConfig['collage']['take_frame'] = false;
+        $Logger->addLogData(['frame' => empty($newConfig['collage']['frame']) ? 'Empty.' : $newConfig['collage']['frame']]);
     }
 
-    if ($newConfig['print']['print_frame']) {
-        if (
-            empty($newConfig['print']['frame']) ||
-            !is_array(
-                @getimagesize(str_starts_with($newConfig['print']['frame'], 'http') ? $newConfig['print']['frame'] : $_SERVER['DOCUMENT_ROOT'] . $newConfig['print']['frame'])
-            )
-        ) {
-            $newConfig['print']['print_frame'] = false;
-            $Logger->addLogData(['frame' => 'Print frame does not exist or is empty. Printing frame disabled.']);
-            $Logger->addLogData(['frame' => empty($newConfig['print']['frame']) ? 'Empty.' : $newConfig['print']['frame']]);
-        }
+    if ($newConfig['print']['print_frame'] && $newConfig['print']['frame'] === '') {
+        $newConfig['print']['print_frame'] = false;
+        $Logger->addLogData(['frame' => empty($newConfig['print']['frame']) ? 'Empty.' : $newConfig['print']['frame']]);
     }
 
-    if ($newConfig['textonpicture']['enabled']) {
-        if (empty($newConfig['textonpicture']['font']) || !file_exists($newConfig['textonpicture']['font'])) {
-            $newConfig['textonpicture']['enabled'] = false;
-            $Logger->addLogData(['font' => 'Picture font does not exist or is empty. Disabled text on picture. Note: Must be an absoloute path.']);
-            $Logger->addLogData(['font' => empty($newConfig['textonpicture']['font']) ? 'Empty.' : $newConfig['textonpicture']['font']]);
-        }
+    if ($newConfig['textonpicture']['enabled'] && ($newConfig['textonpicture']['font'] === '' || !file_exists(PathUtility::getAbsolutePath($newConfig['textonpicture']['font'])))) {
+        $newConfig['textonpicture']['enabled'] = false;
+        $Logger->addLogData(['font' => 'Picture font does not exist or is empty. Disabled text on picture. Note: Must be an absoloute path.']);
+        $Logger->addLogData(['font' => empty($newConfig['textonpicture']['font']) ? 'Empty.' : $newConfig['textonpicture']['font']]);
     }
 
-    if ($newConfig['textoncollage']['enabled']) {
-        if (empty($newConfig['textoncollage']['font']) || !file_exists($newConfig['textoncollage']['font'])) {
-            $newConfig['textoncollage']['enabled'] = false;
-            $Logger->addLogData(['font' => 'Collage font does not exist or is empty. Disabled text on collage. Note: Must be an absoloute path.']);
-            $Logger->addLogData(['font' => empty($newConfig['textoncollage']['font']) ? 'Empty.' : $newConfig['textoncollage']['font']]);
-        }
+    if ($newConfig['textoncollage']['enabled'] && ($newConfig['textoncollage']['font'] === '' || !file_exists(PathUtility::getAbsolutePath($newConfig['textoncollage']['font'])))) {
+        $newConfig['textoncollage']['enabled'] = false;
+        $Logger->addLogData(['font' => 'Collage font does not exist or is empty. Disabled text on collage. Note: Must be an absoloute path.']);
+        $Logger->addLogData(['font' => empty($newConfig['textoncollage']['font']) ? 'Empty.' : $newConfig['textoncollage']['font']]);
     }
 
-    if ($newConfig['textonprint']['enabled']) {
-        if (empty($newConfig['textonprint']['font']) || !file_exists($newConfig['textonprint']['font'])) {
-            $newConfig['textonprint']['enabled'] = false;
-            $Logger->addLogData(['font' => 'Print font does not exist or is empty. Disabled text on print. Note: Must be an absoloute path.']);
-            $Logger->addLogData(['font' => empty($newConfig['textonprint']['font']) ? 'Empty.' : $newConfig['textonprint']['font']]);
-        }
+    if ($newConfig['textonprint']['enabled'] && ($newConfig['textonprint']['font'] === '' || !file_exists(PathUtility::getAbsolutePath($newConfig['textonprint']['font'])))) {
+        $newConfig['textonprint']['enabled'] = false;
+        $Logger->addLogData(['font' => 'Print font does not exist or is empty. Disabled text on print. Note: Must be an absoloute path.']);
+        $Logger->addLogData(['font' => empty($newConfig['textonprint']['font']) ? 'Empty.' : $newConfig['textonprint']['font']]);
     }
 
     if ($newConfig['logo']['enabled']) {
@@ -265,7 +236,7 @@ if (isset($data['type'])) {
             $newConfig['logo']['enabled'] = false;
             $Logger->addLogData(['logo' => 'Logo file path does not exist or is empty. Logo disabled.']);
         } else {
-            $newConfig['logo']['path'] = Helper::fixSeperator($logoPath);
+            $newConfig['logo']['path'] = PathUtility::fixFilePath($logoPath);
             $ext = pathinfo($logoPath, PATHINFO_EXTENSION);
             if ($ext === 'svg') {
                 $Logger->addLogData(['logo' => 'Logo file is SVG, path saved.']);
@@ -283,8 +254,8 @@ if (isset($data['type'])) {
 
     $content = "<?php\n\$config = " . var_export(Helper::arrayRecursiveDiff($newConfig, $defaultConfig), true) . ';';
 
-    if (file_put_contents($my_config_file, $content)) {
-        Helper::clearCache($my_config_file);
+    if (file_put_contents(PathUtility::getAbsolutePath('config/my.config.inc.php'), $content)) {
+        Helper::clearCache(PathUtility::getAbsolutePath('config/my.config.inc.php'));
         $Logger->addLogData(['config' => 'New config saved']);
 
         if ($data['type'] == 'reset') {
@@ -337,8 +308,8 @@ if (isset($data['type'])) {
 
             if ($newConfig['reset']['remove_config']) {
                 // delete personal config
-                if (is_file('../config/my.config.inc.php')) {
-                    unlink('../config/my.config.inc.php');
+                if (is_file(PathUtility::getAbsolutePath('config/my.config.inc.php'))) {
+                    unlink(PathUtility::getAbsolutePath('config/my.config.inc.php'));
                     $Logger->addLogData(['my.config.inc.php' => 'deleted']);
                 }
             }
@@ -373,5 +344,5 @@ if (isset($data['type'])) {
 $Logger->logToFile();
 
 // Kill service daemons after config has changed
-require_once '../lib/services_stop.php';
+require_once PathUtility::getAbsolutePath('lib/services_stop.php');
 exit();

--- a/api/applyEffects.php
+++ b/api/applyEffects.php
@@ -104,14 +104,10 @@ try {
         if (!$isChroma) {
             if ($isCollage && $file != $image) {
                 $editSingleCollage = true;
-                $imageHandler->framePath = str_starts_with($config['collage']['frame'], 'http')
-                    ? $config['collage']['frame']
-                    : $_SERVER['DOCUMENT_ROOT'] . $config['collage']['frame'];
+                $imageHandler->framePath = $config['collage']['frame'];
             } else {
                 $editSingleCollage = false;
-                $imageHandler->framePath = str_starts_with($config['picture']['frame'], 'http')
-                    ? $config['picture']['frame']
-                    : $_SERVER['DOCUMENT_ROOT'] . $config['picture']['frame'];
+                $imageHandler->framePath = $config['picture']['frame'];
             }
 
             if (!$isCollage || $editSingleCollage) {

--- a/api/checkVersion.php
+++ b/api/checkVersion.php
@@ -16,7 +16,7 @@ function getLogData($debugLevel)
         $photobooth = new Photobooth();
         $logData = [
             'updateAvailable' => $photobooth->checkUpdate(),
-            'currentVersion' => $photobooth->getPhotoboothVersion(),
+            'currentVersion' => $photobooth->getVersion(),
             'availableVersion' => $photobooth->getLatestRelease(),
         ];
 

--- a/api/chromakeying/save.php
+++ b/api/chromakeying/save.php
@@ -112,7 +112,7 @@ try {
         }
 
         if ($config['picture']['take_frame']) {
-            $imageHandler->framePath = str_starts_with($config['picture']['frame'], 'http') ? $config['picture']['frame'] : $_SERVER['DOCUMENT_ROOT'] . $config['picture']['frame'];
+            $imageHandler->framePath = $config['picture']['frame'];
             $imageHandler->frameExtend = $config['picture']['extend_by_frame'];
             if ($config['picture']['extend_by_frame']) {
                 $imageHandler->frameExtendLeft = $config['picture']['frame_left_percentage'];

--- a/api/print.php
+++ b/api/print.php
@@ -5,6 +5,7 @@ require_once '../lib/boot.php';
 use Photobooth\DataLogger;
 use Photobooth\PrintManager;
 use Photobooth\Image;
+use Photobooth\Utility\PathUtility;
 
 header('Content-Type: application/json');
 
@@ -75,7 +76,7 @@ if (!file_exists($filename_print)) {
         }
 
         if ($config['print']['print_frame']) {
-            $imageHandler->framePath = str_starts_with($config['print']['frame'], 'http') ? $config['print']['frame'] : $_SERVER['DOCUMENT_ROOT'] . $config['print']['frame'];
+            $imageHandler->framePath = $config['print']['frame'];
             $imageHandler->frameExtend = false;
             $source = $imageHandler->applyFrame($source);
             if (!$source) {
@@ -88,9 +89,9 @@ if (!file_exists($filename_print)) {
             if ($config['ftp']['enabled'] && $config['ftp']['useForQr']) {
                 $imageHandler->qrUrl = $config['ftp']['processedTemplate'] . DIRECTORY_SEPARATOR . $filename;
             } elseif ($config['qr']['append_filename']) {
-                $imageHandler->qrUrl = $config['qr']['url'] . $filename;
+                $imageHandler->qrUrl = PathUtility::getPublicPath($config['qr']['url'] . $filename, true);
             } else {
-                $imageHandler->qrUrl = $config['qr']['url'];
+                $imageHandler->qrUrl = PathUtility::getPublicPath($config['qr']['url'], true);
             }
             $imageHandler->qrSize = $config['print']['qrSize'];
             $imageHandler->qrMargin = $config['print']['qrMargin'];

--- a/api/qrcode.php
+++ b/api/qrcode.php
@@ -1,5 +1,6 @@
 <?php
 
+use Photobooth\Utility\PathUtility;
 use Photobooth\Utility\QrCodeUtility;
 
 require_once '../lib/boot.php';
@@ -10,9 +11,9 @@ if ($filename || !$config['qr']['append_filename']) {
     if ($config['ftp']['enabled'] && $config['ftp']['useForQr']) {
         $url = $config['ftp']['processedTemplate'] . DIRECTORY_SEPARATOR . $filename;
     } elseif ($config['qr']['append_filename']) {
-        $url = $config['qr']['url'] . $filename;
+        $url = PathUtility::getPublicPath($config['qr']['url'] . $filename, true);
     } else {
-        $url = $config['qr']['url'];
+        $url = PathUtility::getPublicPath($config['qr']['url'], true);
     }
     try {
         $result = QrCodeUtility::create($url);

--- a/api/randomImg.php
+++ b/api/randomImg.php
@@ -1,36 +1,23 @@
 <?php
 
+use Photobooth\Utility\ImageUtility;
+
 require_once '../lib/boot.php';
 
-/****************************************************
-            RANDOM FRAME/BACKGROUND/...
-    This "script" allows to randomize images,
-    backgrounds, canvas, frames, etc. so
-    pictures taken are "funnier" and an element
-    of "surprise".
+// RANDOM FRAME/BACKGROUND/...
+//
+// This "script" allows to randomize images,
+// backgrounds, canvas, frames, etc. so
+// pictures taken are "funnier" and an element
+// of "surprise".
 
-*****************************************************/
-
+$directory = 'demoframes';
 if (isset($_GET['dir']) && !empty($_GET['dir'])) {
-    $dir = $_GET['dir'];
-} else {
-    $dir = 'demoframes';
+    $directory = $_GET['dir'];
 }
 
-$path = $config['foldersAbs']['private'] . DIRECTORY_SEPARATOR . 'images' . DIRECTORY_SEPARATOR . $dir;
-
-if ($dir == 'demoframes' || !is_dir($path)) {
-    $path = realpath('../resources/img/frames');
-}
-
-$files = array_diff(scandir($path), ['.', '..']);
-
-// - - - - - - - - - -
-
-$images = array_rand($files);
-$image = $files[$images];
-$filename = $path . DIRECTORY_SEPARATOR . basename($image);
-$file_extension = strtolower(substr(strrchr($filename, '.'), 1));
+$filename = ImageUtility::getRandomImageFromPath($directory);
+$file_extension = strtolower(pathinfo($filename, PATHINFO_EXTENSION));
 
 switch ($file_extension) {
     case 'gif':

--- a/chroma/chromakeying.php
+++ b/chroma/chromakeying.php
@@ -1,14 +1,16 @@
 <?php
 
-$fileRoot = '../';
-require_once($fileRoot . 'lib/boot.php');
+require_once '../lib/boot.php';
+
+use Photobooth\Utility\ImageUtility;
+use Photobooth\Utility\PathUtility;
 
 if (empty($_GET['filename'])) {
     die('No or invalid file provided');
 }
 
 $filename = $_GET['filename'];
-$mainimage = $fileRoot . $config['foldersRoot']['keying'] . DIRECTORY_SEPARATOR . $filename;
+$mainimage = PathUtility::getPublicPath() . $config['foldersRoot']['keying'] . DIRECTORY_SEPARATOR . $filename;
 $imginfo = @getimagesize($config['foldersAbs']['keying'] . DIRECTORY_SEPARATOR . $filename);
 
 if (is_array($imginfo)) {
@@ -18,11 +20,11 @@ if (is_array($imginfo)) {
         $keying_possible = true;
     } else {
         $keying_possible = false;
-        $mainimage = $fileRoot . 'resources/img/bg.jpg';
+        $mainimage = PathUtility::getPublicPath('resources/img/bg.jpg');
     }
 } else {
     $keying_possible = false;
-    $mainimage = $fileRoot . 'resources/img/bg.jpg';
+    $mainimage = PathUtility::getPublicPath('resources/img/bg.jpg');
 }
 
 $pageTitle = $config['ui']['branding'] . ' Chromakeying';
@@ -32,48 +34,45 @@ $remoteBuzzer = true;
 $chromaKeying = true;
 $GALLERY_FOOTER = true;
 
-include($fileRoot . 'template/components/main.head.php');
+include PathUtility::getAbsolutePath('template/components/main.head.php');
 ?>
 
 <body data-main-image="<?=$mainimage?>">
-	<div class="chromawrapper rotarygroup">
-	<?php if ($keying_possible): ?>
-		<div class="canvasWrapper <?php echo $uiShape; ?> noborder initial">
-			<canvas class="<?php echo $uiShape; ?>" id="mainCanvas"></canvas>
-		</div>
+    <div class="chromawrapper rotarygroup">
+    <?php if ($keying_possible): ?>
+        <div class="canvasWrapper <?php echo $uiShape; ?> noborder initial">
+            <canvas class="<?php echo $uiShape; ?>" id="mainCanvas"></canvas>
+        </div>
 
-		<div style="padding-top:10px;text-align:center;">
-		<?php
-            $dir = $fileRoot . $config['keying']['background_path'] . DIRECTORY_SEPARATOR;
-	    $cdir = scandir($dir);
-	    foreach ($cdir as $key => $value) {
-	        if (!in_array($value, ['.', '..']) && !is_dir($dir . $value)) {
-	            echo '<img src="' . $dir . $value . '" class="backgroundPreview ' . $uiShape . ' rotaryfocus" onclick="setBackgroundImage(this.src)">';
-	        }
-	    }
-	    ?>
-		</div>
+        <div style="padding-top:10px;text-align:center;">
+        <?php
+        $backgroundImages = ImageUtility::getImagesFromPath(PathUtility::getAbsolutePath($config['keying']['background_path']));
+        foreach ($backgroundImages as $backgroundImage) {
+            echo '<img src="' . PathUtility::getPublicPath($backgroundImage) . '" class="backgroundPreview ' . $uiShape . ' rotaryfocus" onclick="setBackgroundImage(this.src)">';
+        }
+        ?>
+        </div>
 
-		<div class="chroma-control-bar">
-			<a class="<?php echo $btnClass; ?> rotaryfocus" id="save-chroma-btn" href="#"><i class="<?php echo $config['icons']['save']; ?>"></i> <span data-i18n="save"></span></a>
+        <div class="chroma-control-bar">
+            <a class="<?php echo $btnClass; ?> rotaryfocus" id="save-chroma-btn" href="#"><i class="<?php echo $config['icons']['save']; ?>"></i> <span data-i18n="save"></span></a>
 
-			<?php if ($config['print']['from_chromakeying']): ?>
-				<a class="<?php echo $btnClass; ?> rotaryfocus" id="print-btn" href="#"><i class="<?php echo $config['icons']['print']; ?>"></i> <span data-i18n="print"></span></a>
-			<?php endif; ?>
+            <?php if ($config['print']['from_chromakeying']): ?>
+                <a class="<?php echo $btnClass; ?> rotaryfocus" id="print-btn" href="#"><i class="<?php echo $config['icons']['print']; ?>"></i> <span data-i18n="print"></span></a>
+            <?php endif; ?>
 
-			<a class="<?php echo $btnClass; ?> rotaryfocus" id="close-btn" href="#"><i class="<?php echo $config['icons']['close']; ?>"></i> <span data-i18n="close"></span></a>
-		</div>
-	<?php else:?>
-		<div style="text-align:center;padding-top:250px">
-			<h1 style="color: red;" data-i18n="keyingerror"></h1>
-			<a class="<?php echo $btnClass; ?>" href="<?=$fileRoot?>"><span data-i18n="close"></span></a>
-		</div>
-	<?php endif; ?>
+            <a class="<?php echo $btnClass; ?> rotaryfocus" id="close-btn" href="#"><i class="<?php echo $config['icons']['close']; ?>"></i> <span data-i18n="close"></span></a>
+        </div>
+    <?php else:?>
+        <div style="text-align:center;padding-top:250px">
+            <h1 style="color: red;" data-i18n="keyingerror"></h1>
+            <a class="<?php echo $btnClass; ?>" href="<?=PathUtility::getPublicPath()?>"><span data-i18n="close"></span></a>
+        </div>
+    <?php endif; ?>
 
-		<?php include($fileRoot . 'template/modal.template.php'); ?>
-	</div>
+        <?php include PathUtility::getAbsolutePath('template/modal.template.php'); ?>
+    </div>
 
-	<?php include($fileRoot . 'template/components/main.footer.php'); ?>
-	<?php require_once($fileRoot . 'lib/services_start.php'); ?>
+    <?php include PathUtility::getAbsolutePath('template/components/main.footer.php'); ?>
+    <?php require_once PathUtility::getAbsolutePath('lib/services_start.php'); ?>
 </body>
 </html>

--- a/chroma/index.php
+++ b/chroma/index.php
@@ -1,27 +1,29 @@
 <?php
 
-$fileRoot = '../';
-require_once $fileRoot . 'lib/boot.php';
+require_once '../lib/boot.php';
+
+use Photobooth\Utility\ImageUtility;
+use Photobooth\Utility\PathUtility;
 
 // Login / Authentication check
-if (
+if (!(
     !$config['login']['enabled'] ||
-    (!$config['protect']['localhost_index'] && $_SERVER['REMOTE_ADDR'] === $_SERVER['SERVER_ADDR']) ||
-    ((isset($_SESSION['auth']) && $_SESSION['auth'] === true) || !$config['protect']['index'])
-) {
-    $pageTitle = $config['ui']['branding'] . ' Chroma capture';
-    $mainStyle = $config['ui']['style'] . '_chromacapture.css';
-    $photoswipe = true;
-    $randomImage = false;
-    $remoteBuzzer = true;
-    $chromaKeying = true;
-    $GALLERY_FOOTER = false;
-} else {
-    header('location: ' . $config['protect']['index_redirect']);
+    (!$config['protect']['localhost_index'] && isset($_SERVER['SERVER_ADDR']) &&  $_SERVER['REMOTE_ADDR'] === $_SERVER['SERVER_ADDR']) ||
+    (isset($_SESSION['auth']) && $_SESSION['auth'] === true) || !$config['protect']['index']
+)) {
+    header('location: ' . PathUtility::getPublicPath('login'));
     exit();
 }
 
-include($fileRoot . 'template/components/main.head.php');
+$pageTitle = $config['ui']['branding'] . ' Chroma capture';
+$mainStyle = $config['ui']['style'] . '_chromacapture.css';
+$photoswipe = true;
+$randomImage = false;
+$remoteBuzzer = true;
+$chromaKeying = true;
+$GALLERY_FOOTER = false;
+
+include PathUtility::getAbsolutePath('template/components/main.head.php');
 $btnClass = 'btn btn--' . $config['ui']['button'] . ' chromaCapture-btn';
 ?>
 <body>
@@ -33,7 +35,7 @@ $btnClass = 'btn btn--' . $config['ui']['button'] . ' chromaCapture-btn';
     <div class="rotarygroup" id="start">
         <div class="top-bar">
             <?php if (!$config['chromaCapture']['enabled']): ?>
-                <a href="<?=$fileRoot?>index.php" class="<?php echo $btnClass; ?> chromaCapture-close-btn rotaryfocus"><i class="<?php echo $config['icons']['close']; ?>"></i></a>
+                <a href="<?=PathUtility::getPublicPath()?>index.php" class="<?php echo $btnClass; ?> chromaCapture-close-btn rotaryfocus"><i class="<?php echo $config['icons']['close']; ?>"></i></a>
             <?php endif; ?>
 
             <?php if ($config['gallery']['enabled']): ?>
@@ -50,19 +52,16 @@ $btnClass = 'btn btn--' . $config['ui']['button'] . ' chromaCapture-btn';
             <span data-i18n="chromaInfoBefore"></span>
         </div>
 
-        <?php include($fileRoot . 'template/components/start.loader.php'); ?>
+        <?php include PathUtility::getAbsolutePath('template/components/start.loader.php'); ?>
 
         <!-- Result Page -->
         <div class="stages" id="result"></div>
 
         <div class="backgrounds <?php echo $uiShape ?>">
-            <?php
-            $dir = '..' . DIRECTORY_SEPARATOR . $config['keying']['background_path'] . DIRECTORY_SEPARATOR;
-$cdir = scandir($dir);
-foreach ($cdir as $key => $value) {
-    if (!in_array($value, ['.', '..']) && !is_dir($dir . $value)) {
-        echo '<img src="' . $dir . $value . '" class="' . $uiShape . ' backgroundPreview rotaryfocus" onclick="setBackgroundImage(this.src)">';
-    }
+        <?php
+        $backgroundImages = ImageUtility::getImagesFromPath(PathUtility::getAbsolutePath($config['keying']['background_path']));
+foreach ($backgroundImages as $backgroundImage) {
+    echo '<img src="' . PathUtility::getPublicPath($backgroundImage) . '" class="backgroundPreview ' . $uiShape . ' rotaryfocus" onclick="setBackgroundImage(this.src)">';
 }
 ?>
         </div>
@@ -80,21 +79,21 @@ foreach ($cdir as $key => $value) {
     </div>
     <div class="rotarygroup">
         <div id="wrapper">
-            <?php include($fileRoot . 'template/gallery.template.php'); ?>
+            <?php include PathUtility::getAbsolutePath('template/gallery.template.php'); ?>
         </div>
 
-        <?php include($fileRoot . 'template/send-mail.template.php'); ?>
+        <?php include PathUtility::getAbsolutePath('template/send-mail.template.php'); ?>
     </div>
 </div>
 <script type="text/javascript">
     onCaptureChromaView = true;
 </script>
 
-<?php include($fileRoot . 'template/components/main.footer.php'); ?>
+<?php include PathUtility::getAbsolutePath('template/components/main.footer.php'); ?>
 
-<script type="text/javascript" src="<?=$fileRoot?>resources/js/preview.js?v=<?php echo $config['photobooth']['version']; ?>"></script>
-<script type="text/javascript" src="<?=$fileRoot?>resources/js/core.js?v=<?php echo $config['photobooth']['version']; ?>"></script>
+<script type="text/javascript" src="<?=PathUtility::getPublicPath()?>resources/js/preview.js?v=<?php echo $config['photobooth']['version']; ?>"></script>
+<script type="text/javascript" src="<?=PathUtility::getPublicPath()?>resources/js/core.js?v=<?php echo $config['photobooth']['version']; ?>"></script>
 
-<?php require_once($fileRoot . 'lib/services_start.php'); ?>
+<?php require_once PathUtility::getAbsolutePath('lib/services_start.php'); ?>
 </body>
 </html>

--- a/composer.json
+++ b/composer.json
@@ -6,6 +6,7 @@
         "php": "^8.2",
         "ext-gd": "*",
         "ext-zip": "*",
+        "ext-mbstring": "*",
         "phpmailer/phpmailer": "^6.8",
         "endroid/qr-code": "^4.8"
     },

--- a/config/config.inc.php
+++ b/config/config.inc.php
@@ -271,9 +271,9 @@ $config['qr']['result'] = 'hidden';
 // If send_all_later is enabled, a checkbox to save the current mail address for later in {mail_file}.txt is visible
 $config['mail']['enabled'] = false;
 $config['mail']['send_all_later'] = false;
-$config['mail']['subject'] = ''; 	// if empty, default translation is used
-$config['mail']['text'] = '';		// if empty, default translation is used
-$config['mail']['alt_text'] = '';		// if empty, default translation is used
+$config['mail']['subject'] = '';    // if empty, default translation is used
+$config['mail']['text'] = '';       // if empty, default translation is used
+$config['mail']['alt_text'] = '';   // if empty, default translation is used
 $config['mail']['is_html'] = false;
 $config['mail']['host'] = 'smtp.example.com';
 $config['mail']['username'] = 'photobooth@example.com';

--- a/faq/index.php
+++ b/faq/index.php
@@ -1,49 +1,52 @@
 <?php
 
+use Photobooth\Utility\PathUtility;
+
 require_once('../lib/boot.php');
 
 // Login / Authentication check
-if (
+if (!(
     !$config['login']['enabled'] ||
-    (!$config['protect']['localhost_manual'] && $_SERVER['REMOTE_ADDR'] === $_SERVER['SERVER_ADDR']) ||
-    ((isset($_SESSION['auth']) && $_SESSION['auth'] === true) || !$config['protect']['manual'])
-) {
-    require_once('../lib/configsetup.inc.php');
-} else {
-    header('location: ../login');
+    (!$config['protect']['localhost_manual'] && isset($_SERVER['SERVER_ADDR']) &&  $_SERVER['REMOTE_ADDR'] === $_SERVER['SERVER_ADDR']) ||
+    (isset($_SESSION['auth']) && $_SESSION['auth'] === true) || !$config['protect']['manual']
+)) {
+    header('location: ' . PathUtility::getPublicPath('login'));
     exit();
 }
+
+require_once('../lib/configsetup.inc.php');
 
 ?>
 <!DOCTYPE html>
 <html>
-  <head>
-	<meta charset="UTF-8" />
-	<meta name="viewport" content="width=device-width, initial-scale=1.0 user-scalable=no">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0 user-scalable=no">
+    <meta name="msapplication-TileColor" content="<?=$config['colors']['primary']?>">
+    <meta name="theme-color" content="<?=$config['colors']['primary']?>">
 
-	<title><?=$config['ui']['branding']?> FAQ</title>
+    <title><?=$config['ui']['branding']?> FAQ</title>
 
-	<!-- Favicon + Android/iPhone Icons -->
-	<link rel="apple-touch-icon" sizes="180x180" href="../resources/img/apple-touch-icon.png">
-	<link rel="icon" type="image/png" sizes="32x32" href="../resources/img/favicon-32x32.png">
-	<link rel="icon" type="image/png" sizes="16x16" href="../resources/img/favicon-16x16.png">
-	<link rel="manifest" href="../resources/img/site.webmanifest">
-	<link rel="mask-icon" href="../resources/img/safari-pinned-tab.svg" color="#5bbad5">
+    <!-- Favicon + Android/iPhone Icons -->
+    <link rel="apple-touch-icon" sizes="180x180" href="<?=PathUtility::getPublicPath()?>resources/img/apple-touch-icon.png">
+    <link rel="icon" type="image/png" sizes="32x32" href="<?=PathUtility::getPublicPath()?>resources/img/favicon-32x32.png">
+    <link rel="icon" type="image/png" sizes="16x16" href="<?=PathUtility::getPublicPath()?>resources/img/favicon-16x16.png">
+    <link rel="manifest" href="<?=PathUtility::getPublicPath()?>resources/img/site.webmanifest">
+    <link rel="mask-icon" href="<?=PathUtility::getPublicPath()?>resources/img/safari-pinned-tab.svg" color="#5bbad5">
 
-	<!-- Fullscreen Mode on old iOS-Devices when starting photobooth from homescreen -->
-	<meta name="apple-mobile-web-app-capable" content="yes" />
-	<meta name="apple-mobile-web-app-status-bar-style" content="black" />
+    <!-- Fullscreen Mode on old iOS-Devices when starting photobooth from homescreen -->
+    <meta name="apple-mobile-web-app-capable" content="yes" />
+    <meta name="apple-mobile-web-app-status-bar-style" content="black" />
     <link rel="stylesheet" type="text/css" href="../node_modules/github-markdown-css/github-markdown.css">
-  </head>
-  <body class="markdown-body" style="padding: 5rem;">
+</head>
+<body class="markdown-body" style="padding: 5rem;">
 
-	
-	<?php
-        if(file_exists('faq.md.php')) {
-            include('faq.md.php');
-        } else {
-            echo '<p>The file <code>faq/faq.md.php</code> does not exist. Please run <code>npm run build:faq</code> to generate it.</p>';
-        }
+<?php
+    if(file_exists(PathUtility::getAbsolutePath('faq/faq.md.php'))) {
+        include PathUtility::getAbsolutePath('faq/faq.md.php');
+    } else {
+        echo '<p>The file <code>faq/faq.md.php</code> does not exist. Please run <code>npm run build:faq</code> to generate it.</p>';
+    }
 ?>
 
   </body>

--- a/gallery/index.php
+++ b/gallery/index.php
@@ -1,7 +1,8 @@
 <?php
 
-$fileRoot = '../';
-require_once($fileRoot . 'lib/boot.php');
+require_once '../lib/boot.php';
+
+use Photobooth\Utility\PathUtility;
 
 $pageTitle = $config['ui']['branding'] . ' Gallery';
 $mainStyle = $config['ui']['style'] . '_style.css';
@@ -11,27 +12,27 @@ $remoteBuzzer = true;
 $chromaKeying = false;
 $GALLERY_FOOTER = false;
 
-include($fileRoot . 'template/components/main.head.php');
+include PathUtility::getAbsolutePath('template/components/main.head.php');
 ?>
 <body class="deselect">
-	<div id="wrapper">
-		<?php include($fileRoot . 'template/gallery.template.php'); ?>
-	</div>
+    <div id="wrapper">
+        <?php include PathUtility::getAbsolutePath('template/gallery.template.php'); ?>
+    </div>
 
-	<script type="text/javascript">
-		onStandaloneGalleryView = true;
-	</script>
+    <script type="text/javascript">
+        onStandaloneGalleryView = true;
+    </script>
 
-	<?php include($fileRoot . 'template/send-mail.template.php'); ?>
-	<?php include($fileRoot . 'template/components/main.footer.php'); ?>
+    <?php include PathUtility::getAbsolutePath('template/send-mail.template.php'); ?>
+    <?php include PathUtility::getAbsolutePath('template/components/main.footer.php'); ?>
 
-	<script type="text/javascript" src="<?=$fileRoot?>resources/js/preview.js?v=<?php echo $config['photobooth']['version']; ?>"></script>
-	<script type="text/javascript" src="<?=$fileRoot?>resources/js/core.js?v=<?php echo $config['photobooth']['version']; ?>"></script>
-	<script type="text/javascript" src="<?=$fileRoot?>resources/js/gallery.js?v=<?php echo $config['photobooth']['version']; ?>"></script>
-	<?php if ($config['gallery']['db_check_enabled']): ?>
-	<script type="text/javascript" src="<?=$fileRoot?>resources/js/gallery_updatecheck.js?v=<?php echo $config['photobooth']['version']; ?>"></script>
-	<?php endif; ?>
+    <script type="text/javascript" src="<?=PathUtility::getPublicPath()?>resources/js/preview.js?v=<?php echo $config['photobooth']['version']; ?>"></script>
+    <script type="text/javascript" src="<?=PathUtility::getPublicPath()?>resources/js/core.js?v=<?php echo $config['photobooth']['version']; ?>"></script>
+    <script type="text/javascript" src="<?=PathUtility::getPublicPath()?>resources/js/gallery.js?v=<?php echo $config['photobooth']['version']; ?>"></script>
+    <?php if ($config['gallery']['db_check_enabled']): ?>
+    <script type="text/javascript" src="<?=PathUtility::getPublicPath()?>resources/js/gallery_updatecheck.js?v=<?php echo $config['photobooth']['version']; ?>"></script>
+    <?php endif; ?>
 
-	<?php require_once($fileRoot . 'lib/services_start.php'); ?>
+    <?php require_once PathUtility::getAbsolutePath('lib/services_start.php'); ?>
 </body>
 </html>

--- a/index.php
+++ b/index.php
@@ -1,17 +1,18 @@
 <?php
 
-$fileRoot = '';
-require_once $fileRoot . 'lib/boot.php';
+require_once 'lib/boot.php';
+
+use Photobooth\Utility\PathUtility;
 
 if (!$config['ui']['skip_welcome']) {
-    if (!is_file($fileRoot . 'welcome/.skip_welcome')) {
-        header('location: ' . $fileRoot . 'welcome/');
+    if (!is_file(PathUtility::getAbsolutePath('welcome/.skip_welcome'))) {
+        header('location: ' . PathUtility::getPublicPath('welcome'));
         exit();
     }
 }
 
 if ($config['chromaCapture']['enabled']) {
-    header('location: ' . $fileRoot . 'chroma/');
+    header('location: ' . PathUtility::getPublicPath('chroma'));
     exit();
 }
 
@@ -33,8 +34,8 @@ if (
     exit();
 }
 
-include($fileRoot . 'template/components/helper/index.php');
-include($fileRoot . 'template/components/main.head.php');
+include PathUtility::getAbsolutePath('template/components/helper/index.php');
+include PathUtility::getAbsolutePath('template/components/main.head.php');
 ?>
 
 <body class="deselect">
@@ -65,36 +66,35 @@ include($fileRoot . 'template/components/main.head.php');
     </div>
 <?php endif; ?>
 <div id="wrapper">
+<?php
 
-    <?php
-        include($fileRoot . 'template/' . $config['ui']['style'] . '.template.php');
+include PathUtility::getAbsolutePath('template/' . $config['ui']['style'] . '.template.php');
 
 if ($config['filters']['enabled']) {
-    include($fileRoot . 'template/components/start.filter.php');
+    include PathUtility::getAbsolutePath('template/components/start.filter.php');
 }
 
-include($fileRoot . 'template/components/start.loader.php');
-include($fileRoot . 'template/components/start.results.php');
+include PathUtility::getAbsolutePath('template/components/start.loader.php');
+include PathUtility::getAbsolutePath('template/components/start.results.php');
 
 if ($config['gallery']['enabled']) {
-    include($fileRoot . 'template/gallery.template.php');
+    include PathUtility::getAbsolutePath('template/gallery.template.php');
 }
+
 ?>
-
-
 </div>
 
 <?php
-include($fileRoot . 'template/send-mail.template.php');
-include($fileRoot . 'template/modal.template.php');
-include($fileRoot . 'template/components/adminShortcut.php');
-include($fileRoot . 'template/components/main.footer.php');
+include PathUtility::getAbsolutePath('template/send-mail.template.php');
+include PathUtility::getAbsolutePath('template/modal.template.php');
+include PathUtility::getAbsolutePath('template/components/adminShortcut.php');
+include PathUtility::getAbsolutePath('template/components/main.footer.php');
 ?>
 
-<script type="text/javascript" src="<?=$fileRoot?>resources/js/adminshortcut.js?v=<?php echo $config['photobooth']['version']; ?>"></script>
-<script type="text/javascript" src="<?=$fileRoot?>resources/js/preview.js?v=<?php echo $config['photobooth']['version']; ?>"></script>
-<script type="text/javascript" src="<?=$fileRoot?>resources/js/core.js?v=<?php echo $config['photobooth']['version']; ?>"></script>
+<script type="text/javascript" src="<?=PathUtility::getPublicPath()?>resources/js/adminshortcut.js?v=<?php echo $config['photobooth']['version']; ?>"></script>
+<script type="text/javascript" src="<?=PathUtility::getPublicPath()?>resources/js/preview.js?v=<?php echo $config['photobooth']['version']; ?>"></script>
+<script type="text/javascript" src="<?=PathUtility::getPublicPath()?>resources/js/core.js?v=<?php echo $config['photobooth']['version']; ?>"></script>
 
-<?php require_once($fileRoot . 'lib/services_start.php'); ?>
+<?php require_once PathUtility::getAbsolutePath('lib/services_start.php'); ?>
 </body>
 </html>

--- a/install-photobooth.sh
+++ b/install-photobooth.sh
@@ -59,6 +59,7 @@ COMMON_PACKAGES=(
         'nodejs'
         'php-gd'
         'php-zip'
+        'php-mbstring'
         'python3'
         'python3-gphoto2'
         'python3-psutil'

--- a/lib/boot.php
+++ b/lib/boot.php
@@ -1,5 +1,7 @@
 <?php
 
+use Photobooth\Utility\PathUtility;
+
 session_start();
 
 // Autoload
@@ -47,7 +49,7 @@ define('TEXTONCOLLAGE_LINE3', $config['textoncollage']['line3']);
 define('TEXTONCOLLAGE_LOCATIONX', $config['textoncollage']['locationx']);
 define('TEXTONCOLLAGE_LOCATIONY', $config['textoncollage']['locationy']);
 define('TEXTONCOLLAGE_ROTATION', $config['textoncollage']['rotation']);
-define('TEXTONCOLLAGE_FONT', $config['textoncollage']['font']);
+define('TEXTONCOLLAGE_FONT', PathUtility::getAbsolutePath($config['textoncollage']['font']));
 define('TEXTONCOLLAGE_FONT_COLOR', $config['textoncollage']['font_color']);
 define('TEXTONCOLLAGE_FONT_SIZE', $config['textoncollage']['font_size']);
 define('TEXTONCOLLAGE_LINESPACE', $config['textoncollage']['linespace']);

--- a/lib/config.php
+++ b/lib/config.php
@@ -8,12 +8,9 @@ use Photobooth\Environment;
 use Photobooth\Photobooth;
 use Photobooth\Helper;
 use Photobooth\Utility\ArrayUtility;
+use Photobooth\Utility\PathUtility;
 
 $photobooth = new Photobooth();
-$default_config_file = __DIR__ . '/../config/config.inc.php';
-$my_config_file = __DIR__ . '/../config/my.config.inc.php';
-$basepath = __DIR__ . DIRECTORY_SEPARATOR . '..' . DIRECTORY_SEPARATOR;
-$rootpath = Helper::fixSeperator(Helper::getRootpath($basepath));
 
 $cmds = [
     'windows' => [
@@ -98,7 +95,7 @@ $mailTemplates = [
     ],
 ];
 
-require_once $default_config_file;
+require_once PathUtility::getAbsolutePath('config/config.inc.php');
 
 $environment = new Environment();
 $config['take_picture']['cmd'] = $cmds[$environment->getOperatingSystem()]['take_picture']['cmd'];
@@ -120,8 +117,8 @@ $config['ui']['branding'] = 'Photobooth';
 
 $defaultConfig = $config;
 
-if (file_exists($my_config_file)) {
-    require_once $my_config_file;
+if (file_exists(PathUtility::getAbsolutePath('config/my.config.inc.php'))) {
+    require_once PathUtility::getAbsolutePath('config/my.config.inc.php');
 
     if (empty($config['mail']['subject'])) {
         if (!empty($config['ui']['language'])) {
@@ -147,26 +144,25 @@ if ($config['dev']['loglevel'] > 0) {
     error_reporting(E_ALL);
 }
 
-if (file_exists($my_config_file) && !is_writable($my_config_file)) {
+if (file_exists(PathUtility::getAbsolutePath('config/my.config.inc.php')) && !is_writable(PathUtility::getAbsolutePath('config/my.config.inc.php'))) {
     die('Abort. Can not write config/my.config.inc.php.');
-} elseif (!file_exists($my_config_file) && !is_writable(__DIR__ . '/../config/')) {
+} elseif (!file_exists(PathUtility::getAbsolutePath('config/my.config.inc.php')) && !is_writable(__DIR__ . '/../config/')) {
     die('Abort. Can not create config/my.config.inc.php. Config folder is not writable.');
 }
 
 if (empty($config['ui']['folders_lang'])) {
-    $config['ui']['folders_lang'] = $rootpath . '/resources/lang';
+    $config['ui']['folders_lang'] = 'resources/lang';
 }
 
-$config['ui']['folders_lang'] = Helper::setAbsolutePath(Helper::fixSeperator($config['ui']['folders_lang']));
+$config['ui']['folders_lang'] = PathUtility::getPublicPath($config['ui']['folders_lang']);
 
 foreach ($config['folders'] as $key => $folder) {
     if ($folder === 'data' || $folder === 'archives' || $folder === 'config' || $folder === 'private') {
-        $path = $basepath . $folder;
+        $path = PathUtility::getAbsolutePath($folder);
     } else {
-        $path = $basepath . $config['folders']['data'] . DIRECTORY_SEPARATOR . $folder;
+        $path = PathUtility::getAbsolutePath($config['folders']['data'] . DIRECTORY_SEPARATOR . $folder);
         $config['foldersRoot'][$key] = $config['folders']['data'] . DIRECTORY_SEPARATOR . $folder;
-
-        $config['foldersJS'][$key] = Helper::fixSeperator(Helper::getRootpath($path));
+        $config['foldersJS'][$key] = PathUtility::getPublicPath($path);
     }
 
     if (!file_exists($path)) {
@@ -177,12 +173,11 @@ foreach ($config['folders'] as $key => $folder) {
         die("Abort. The folder $folder is not writable.");
     }
 
-    $path = realpath($path);
-    $config['foldersAbs'][$key] = $path;
+    $config['foldersAbs'][$key] = PathUtility::getAbsolutePath($path);
 }
 
-$config['foldersJS']['api'] = Helper::fixSeperator(Helper::getRootpath($basepath . 'api'));
-$config['foldersJS']['chroma'] = Helper::fixSeperator(Helper::getRootpath($basepath . 'chroma'));
+$config['foldersJS']['api'] = PathUtility::getPublicPath('api');
+$config['foldersJS']['chroma'] = PathUtility::getPublicPath('chroma');
 
 define('PRINT_DB', $config['foldersAbs']['data'] . DIRECTORY_SEPARATOR . 'printed.csv');
 define('PRINT_LOCKFILE', $config['foldersAbs']['data'] . DIRECTORY_SEPARATOR . 'print.lock');
@@ -198,10 +193,10 @@ if (!empty($config['preview']['killcmd']) && $config['preview']['stop_time'] < $
     $config['preview']['stop_time'] = $config['picture']['cntdwn_offset'] + 1;
 }
 
-$default_font = realpath($basepath . 'resources/fonts/GreatVibes-Regular.ttf');
-$default_frame = Helper::setAbsolutePath($rootpath . '/resources/img/frames/frame.png');
-$random_frame = $photobooth->getUrl() . '/api/randomImg.php?dir=demoframes';
-$default_template = realpath($basepath . DIRECTORY_SEPARATOR . 'resources/template/index.php');
+$default_font = PathUtility::getPublicPath('resources/fonts/GreatVibes-Regular.ttf');
+$default_frame = PathUtility::getPublicPath('resources/img/frames/frame.png');
+$random_frame = PathUtility::getPublicPath('api/randomImg.php?dir=demoframes');
+$default_template = realpath(PathUtility::getRootPath() . DIRECTORY_SEPARATOR . 'resources/template/index.php');
 
 if (empty($config['picture']['frame'])) {
     $config['picture']['frame'] = $random_frame;
@@ -216,7 +211,7 @@ if (empty($config['collage']['frame'])) {
 }
 
 if (empty($config['collage']['placeholderpath'])) {
-    $config['collage']['placeholderpath'] = Helper::setAbsolutePath($rootpath . '/resources/img/background/01.jpg');
+    $config['collage']['placeholderpath'] = PathUtility::getPublicPath('resources/img/background/01.jpg');
 }
 
 if (empty($config['textoncollage']['font'])) {
@@ -235,8 +230,8 @@ if (empty($config['collage']['limit'])) {
     $config['collage']['limit'] = 4;
 }
 
-$bg_url = Helper::setAbsolutePath($rootpath . '/resources/img/background.png');
-$logo_url = Helper::setAbsolutePath($rootpath . '/resources/img/logo/logo-qrcode-text.png');
+$bg_url = PathUtility::getPublicPath('resources/img/background.png');
+$logo_url = PathUtility::getPublicPath('resources/img/logo/logo-qrcode-text.png');
 
 if (empty($config['logo']['path'])) {
     $config['logo']['path'] = $logo_url;
@@ -271,7 +266,7 @@ if (empty($config['remotebuzzer']['serverip'])) {
 }
 
 if (empty($config['qr']['url'])) {
-    $config['qr']['url'] = $photobooth->getUrl() . '/api/download.php?image=';
+    $config['qr']['url'] = PathUtility::getPublicPath('api/download.php?image=');
 }
 
 if (empty($config['ftp']['template_location']) || !Helper::testFile($config['ftp']['template_location'])) {
@@ -300,9 +295,4 @@ if (!empty($config['ftp']['urlTemplate'])) {
     $config['ftp']['processedTemplate'] = str_replace(array_keys($parameters), array_values($parameters), $config['ftp']['urlTemplate']);
 }
 
-$config['cheese_img'] = $config['ui']['shutter_cheese_img'];
-if (!empty($config['cheese_img'])) {
-    $config['cheese_img'] = Helper::setAbsolutePath($rootpath . $config['ui']['shutter_cheese_img']);
-}
-
-$config['photobooth']['version'] = $photobooth->version;
+$config['photobooth']['version'] = $photobooth->getVersion();

--- a/lib/services_start.php
+++ b/lib/services_start.php
@@ -1,5 +1,7 @@
 <?php
 
+use Photobooth\Utility\PathUtility;
+
 function processIsRunning($pName, $pidFile)
 {
     if (file_exists($pidFile)) {
@@ -25,9 +27,7 @@ if ($config['remotebuzzer']['startserver'] && ($config['remotebuzzer']['usebutto
         }
 
         echo '<!-- Remote Buzzer enabled --- starting server -->' . "\n";
-        if (!empty($fileRoot)) {
-            chdir($fileRoot);
-        }
+        chdir(PathUtility::getRootPath());
         proc_close(proc_open($config['nodebin']['cmd'] . ' resources/js/remotebuzzer_server.js 1>' . $logfile . ' 2>&1 &', [], $foo));
     } else {
         echo '<!-- Remote Buzzer Enabled --- server already started (port in use) -->' . "\n";
@@ -45,9 +45,7 @@ if ($config['synctodrive']['enabled']) {
         echo '<!-- Sync To Drive enabled --- server already active -->' . "\n";
     } else {
         echo '<!-- Sync To Drive enabled --- starting server -->' . "\n";
-        if (!empty($fileRoot)) {
-            chdir($fileRoot);
-        }
+        chdir(PathUtility::getRootPath());
         proc_close(proc_open($config['nodebin']['cmd'] . ' resources/js/sync-to-drive.js 1>' . $logfile . ' 2>&1 &', [], $foo));
     }
 }

--- a/lib/src/Helper.php
+++ b/lib/src/Helper.php
@@ -15,45 +15,6 @@ class Helper
     private static $units = ['B', 'KB', 'MB', 'GB', 'TB', 'PB'];
 
     /**
-     * Get the relative path of a file or directory.
-     *
-     * @param string $relative_path The path to the file or directory relative to the application root.
-     *
-     * @return string The relative path of the file or directory.
-     */
-    public static function getRootpath($relative_path = __DIR__ . DIRECTORY_SEPARATOR . '..' . DIRECTORY_SEPARATOR)
-    {
-        return str_replace(Photobooth::getWebRoot(), '', realpath($relative_path));
-    }
-
-    /**
-     * Fix path separators to use forward slashes instead of backslashes.
-     *
-     * @param string $fixPath The path to be fixed.
-     *
-     * @return string The fixed path.
-     */
-    public static function fixSeperator($fixPath)
-    {
-        return str_replace('\\', '/', $fixPath);
-    }
-
-    /**
-     * Set an absolute path by adding a leading slash if necessary.
-     *
-     * @param string $path The path to be set as absolute.
-     *
-     * @return string The absolute path.
-     */
-    public static function setAbsolutePath($path)
-    {
-        if (!empty($path) && $path[0] != '/') {
-            $path = '/' . $path;
-        }
-        return $path;
-    }
-
-    /**
      * Recursively compares two arrays and returns the differences between them.
      *
      * @param array $array1 The first array to compare.

--- a/lib/src/Image.php
+++ b/lib/src/Image.php
@@ -3,6 +3,8 @@
 namespace Photobooth;
 
 use GdImage;
+use Photobooth\Utility\ImageUtility;
+use Photobooth\Utility\PathUtility;
 use Photobooth\Utility\QrCodeUtility;
 
 class Image
@@ -370,6 +372,13 @@ class Image
     public function createFromImage($image)
     {
         try {
+            if (str_contains($image, '/api/randomImg.php')) {
+                parse_str(parse_url($image)['query'] ?? '', $query);
+                $image = ImageUtility::getRandomImageFromPath($query['dir'] ?? '');
+            } elseif (PathUtility::isAbsolutePath(PathUtility::getAbsolutePath($image))) {
+                $image = PathUtility::getAbsolutePath($image);
+            }
+
             $resource = imagecreatefromstring(file_get_contents($image));
             if (!$resource) {
                 throw new \Exception('Can\'t create GD resource.');
@@ -797,7 +806,7 @@ class Image
             $fontRotation = $this->fontRotation;
             $fontLocationX = $this->fontLocationX;
             $fontLocationY = $this->fontLocationY;
-            $fontPath = $this->fontPath;
+            $fontPath = PathUtility::getAbsolutePath($this->fontPath);
             $textLineSpacing = $this->textLineSpacing;
             // Convert hex color string to RGB values
             list($r, $g, $b) = sscanf($this->fontColor, '#%02x%02x%02x');

--- a/lib/src/Utility/ImageUtility.php
+++ b/lib/src/Utility/ImageUtility.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Photobooth\Utility;
+
+class ImageUtility
+{
+    // svg is not working as image
+    public const supportedFileExtensions = [
+        'gif',
+        'png',
+        'jpeg',
+        'jpg',
+    ];
+
+    public const resourcePaths = [
+        'resources/img/background',
+        'resources/img/frames',
+        'resources/img/demo'
+    ];
+
+    public static function getImagesFromPath(string $path): array
+    {
+        if (!PathUtility::isAbsolutePath($path)) {
+            $path = PathUtility::getAbsolutePath($path);
+        }
+        if (!PathUtility::isAbsolutePath($path)) {
+            throw new \Exception('Path ' . $path . ' does not exist.');
+        }
+
+        $files = [];
+        foreach (new \DirectoryIterator($path) as $file) {
+            if(!$file->isFile() || !in_array(strtolower($file->getExtension()), self::supportedFileExtensions)) {
+                continue;
+            }
+            $files[] = $path . '/' . $file->getFilename();
+        }
+
+        return $files;
+    }
+
+    public static function getRandomImageFromPath(string $path): string
+    {
+        if ($path === '' || $path === 'demoframes') {
+            $path = 'resources/img/frames';
+        }
+
+        if (!in_array($path, self::resourcePaths)) {
+            $path = 'private/' . $path;
+        }
+
+        $files = self::getImagesFromPath($path);
+        if (count($files) === 0) {
+            throw new \Exception('Path ' . $path . ' does not contain images.');
+        }
+
+        return $files[array_rand($files)];
+    }
+}

--- a/lib/src/Utility/PathUtility.php
+++ b/lib/src/Utility/PathUtility.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace Photobooth\Utility;
+
+class PathUtility
+{
+    public static function getRootPath(): string
+    {
+        return realpath(self::fixFilePath(__DIR__ . '/../../../'));
+    }
+
+    public static function getAbsolutePath(string $path = ''): string
+    {
+        if (self::isAbsolutePath($path)) {
+            return $path;
+        }
+
+        $path = self::fixFilePath('/' . $path);
+        $path = self::fixFilePath(str_replace(self::getRootPath(), '', $path));
+        $path = self::fixFilePath(self::getRootPath() . $path);
+
+        return $path;
+    }
+
+    public static function isAbsolutePath(string $path): bool
+    {
+        return realpath($path) !== false;
+    }
+
+    public static function isUrl(string $path): bool
+    {
+        return str_starts_with($path, 'http');
+    }
+
+    public static function getPublicPath(string $path = '', bool $absolute = false): string
+    {
+        if (self::isUrl($path)) {
+            return $path;
+        }
+
+        $path = self::fixFilePath(self::getBaseUrl() . $path);
+        $path = self::fixFilePath(str_replace(self::getRootPath(), '', $path));
+        $path = self::fixFilePath(self::resolveRelativePath($path));
+
+        if ($absolute) {
+            $path = (isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] != 'off' ? 'https' : 'http') . '//' . $_SERVER['SERVER_NAME'] . $path;
+        }
+
+        return $path;
+    }
+
+    public static function getBaseUrl(): string
+    {
+        return self::fixFilePath(str_replace($_SERVER['DOCUMENT_ROOT'], '', self::getAbsolutePath()));
+    }
+
+    public static function fixFilePath(string $path): string
+    {
+        return str_replace(['\\', '//'], '/', $path);
+    }
+
+    protected static function resolveRelativePath(string $relativePath): string
+    {
+        $segments = explode('/', $relativePath);
+        $resolvedPath = '';
+        foreach ($segments as $segment) {
+            if ($segment === '..') {
+                $resolvedPath = dirname($resolvedPath);
+            } elseif ($segment !== '.') {
+                $resolvedPath .= '/' . $segment;
+            }
+        }
+
+        return $resolvedPath;
+    }
+}

--- a/login/index.php
+++ b/login/index.php
@@ -1,7 +1,8 @@
 <?php
 
-$fileRoot = '../';
-require_once($fileRoot . 'lib/boot.php');
+use Photobooth\Utility\PathUtility;
+
+require_once '../lib/boot.php';
 
 // LOGIN
 $username = $config['login']['username'];
@@ -20,8 +21,8 @@ if (isset($_POST['submit'])) {
 // END LOGIN
 
 $pageTitle = 'Login';
-include($fileRoot . 'admin/components/head.admin.php');
-include($fileRoot . 'admin/helper/index.php');
+include PathUtility::getAbsolutePath('admin/components/head.admin.php');
+include PathUtility::getAbsolutePath('admin/helper/index.php');
 
 $labelClass = 'w-full flex flex-col mb-1';
 $inputClass = 'w-full h-10 border border-solid border-gray-300 focus:border-brand-1 rounded-md px-3 mt-auto';
@@ -29,41 +30,41 @@ $btnClass = 'w-full h-12 rounded-full bg-brand-1 text-white flex items-center ju
 ?>
 
 <body>
-	<div class="w-full h-screen grid place-items-center absolute bg-brand-2 px-6 py-12 overflow-x-hidden overflow-y-auto">
-		<div class="w-full flex items-center justify-center flex-col">
+    <div class="w-full h-screen grid place-items-center absolute bg-brand-2 px-6 py-12 overflow-x-hidden overflow-y-auto">
+        <div class="w-full flex items-center justify-center flex-col">
 
-		<?php
+        <?php
             if($config['login']['enabled'] && !(isset($_SESSION['auth']) && $_SESSION['auth'] === true) && !(isset($_SESSION['rental']))) {
                 if(isset($config['login']['keypad']) && $config['login']['keypad'] === true) {
-                    include('keypad.php');
+                    include PathUtility::getAbsolutePath('login/keypad.php');
                 } else {
-                    include('loginMask.php');
+                    include PathUtility::getAbsolutePath('login/loginMask.php');
                 }
 
                 if(!$config['login']['rental_keypad']) {
                     echo '<div class="w-full max-w-xl my-12 border-b border-solid border-white border-opacity-20"></div>';
-                    include('menu.php');
+                    include PathUtility::getAbsolutePath('login/menu.php');
                 }
             } else {
-                include('menu.php');
+                include PathUtility::getAbsolutePath('login/menu.php');
             }
 ?>
 
-		
+
 <?php
     if((isset($_SESSION['auth']) && $_SESSION['auth'] === true) || isset($_SESSION['rental'])) {
         echo'<script>
-			setTimeout(function() {
-				window.location = "' . $fileRoot . '/login/logout.php";
-			}, 60000);
-		</script>';
+            setTimeout(function() {
+                window.location = "' . PathUtility::getPublicPath('login/logout.php') . '";
+            }, 60000);
+        </script>';
     } else {
         echo'<script>
-			setTimeout(function() {
-				window.location = "' . $fileRoot . '";
-			}, 30000);
-		</script>';
+            setTimeout(function() {
+                window.location = "' . PathUtility::getPublicPath() . '";
+            }, 30000);
+        </script>';
     }
 
-    include($fileRoot . 'admin/components/footer.admin.php');
+    include PathUtility::getAbsolutePath('admin/components/footer.admin.php');
 ?>

--- a/login/keypad.php
+++ b/login/keypad.php
@@ -1,4 +1,7 @@
 <?php
+
+use Photobooth\Utility\PathUtility;
+
 $pinLength = strlen($config['login']['pin']);
 $pinMap = str_split($config['login']['pin']);
 
@@ -12,15 +15,15 @@ function getKeyIndicator($pinMap, $length)
         }
 
         $containerClass = '
-                keypad_keybox ' . $activeClass . ' 
-                flex items-center justify-center w-10 h-14 
-                border border-solid border-gray-200 bg-gray-50 rounded m-2 
-                [&.active]:border-brand-1 
+                keypad_keybox ' . $activeClass . '
+                flex items-center justify-center w-10 h-14
+                border border-solid border-gray-200 bg-gray-50 rounded m-2
+                [&.active]:border-brand-1
                 [&.error]:animate-error [&.error]:border-red-500 [&.error]:border-opacity-70
             ';
         $dotClass = '
-                keypad_key ' . $activeClass . ' 
-                w-3 h-3 rounded-full bg-gray-400 
+                keypad_key ' . $activeClass . '
+                w-3 h-3 rounded-full bg-gray-400
                 [&.active]:border-2 [&.active]:border-solid [&.active]:border-brand-1 [&.active]:bg-transparent
                 [&.checked]:bg-brand-1
                 [&.error]:bg-red-500 [&.error]:bg-opacity-70
@@ -33,7 +36,6 @@ function getKeyIndicator($pinMap, $length)
 }
 function getKey($key = null)
 {
-    global $fileRoot;
     $containerClass = 'keypad_key peer flex items-center justify-center p-2 hover:text-brand-1 transition-all';
     $keyClass = '
             flex items-center justify-center w-16 h-16 transition-all
@@ -52,7 +54,7 @@ function getKey($key = null)
         } elseif ($key  === 'remove') {
             echo '<div class="' . $containerClass . ' cursor-pointer" onclick="keypadRemoveLastValue();"><span class="fa fa-chevron-left"></span></div>';
         } elseif ($key  === 'home') {
-            echo '<a href="' . $fileRoot . '" class="text-2xl ' . $containerClass . ' cursor-pointer"><span class="fa fa-home"></span></a>';
+            echo '<a href="' . PathUtility::getPublicPath() . '" class="text-2xl ' . $containerClass . ' cursor-pointer"><span class="fa fa-home"></span></a>';
         }
     } else {
         echo '<div class="' . $containerClass . '"></div>';
@@ -78,8 +80,9 @@ function getKey($key = null)
 
         <div class="w-full text-center text-gray-500">
             <div class="grid grid-cols-3">
-                <?php
-                    echo getKey(1);
+<?php
+
+echo getKey(1);
 echo getKey(2);
 echo getKey(3);
 echo getKey(4);
@@ -91,6 +94,7 @@ echo getKey(9);
 echo getKey('remove');
 echo getKey(0);
 echo getKey('home');
+
 ?>
             </div>
         </div>

--- a/login/logout.php
+++ b/login/logout.php
@@ -1,5 +1,7 @@
 <?php
 
+use Photobooth\Utility\PathUtility;
+
 if (!isset($_SESSION)) {
     session_start();
 }
@@ -8,5 +10,5 @@ session_destroy();
 unset($_SESSION['auth']);
 unset($_SESSION['rental']);
 
-header('location: ../');
+header('location: ' . PathUtility::getPublicPath());
 exit;

--- a/login/menu.php
+++ b/login/menu.php
@@ -1,3 +1,8 @@
+<?php
+
+use Photobooth\Utility\PathUtility;
+
+?>
 
 <div class="w-full max-w-xl rounded-lg py-8 bg-white flex flex-col shadow-xl relative">
 
@@ -7,14 +12,14 @@
                 if((isset($_SESSION['auth']) && $_SESSION['auth'] === true)) {
                     echo 'Admin -';
                 }
-            ?>
+?>
             <span data-i18n="menu"></span>
         </h1>
     </div>
 
     <?php if(!$config['protect']['index'] || (!$config['protect']['localhost_index'] && (isset($_SERVER['SERVER_ADDR']) && $_SERVER['REMOTE_ADDR'] === $_SERVER['SERVER_ADDR'])) || !$config['login']['enabled'] || (isset($_SESSION['auth']) && $_SESSION['auth'] === true)): ?>
         <div class="w-12 h-12 bg-white absolute right-4 top-4 rounded-b-l-lg shadow-xls flex items-center justify-center text-brand-1 cursor-pointer">
-            <a href="<?=$fileRoot?>" >
+            <a href="<?=PathUtility::getPublicPath('')?>" >
                 <i class="!text-2xl <?php echo $config['icons']['close']; ?>"></i>
                 <!-- <span data-i18n="close"></span> -->
             </a>
@@ -23,41 +28,41 @@
 
     <div class="grid grid-cols-1 md:grid-cols-2 gap-4 px-4 ">
         <?php
-            if(!$config['protect']['admin'] || (!$config['protect']['localhost_admin'] && (isset($_SERVER['SERVER_ADDR']) && $_SERVER['REMOTE_ADDR'] === $_SERVER['SERVER_ADDR'])) || !$config['login']['enabled'] || (isset($_SESSION['auth']) && $_SESSION['auth'] === true)) {
-                echo getMenuBtn($fileRoot . 'admin', 'admin_panel', $config['icons']['admin']);
-                echo getMenuBtn($fileRoot . 'test', 'testMenu', $config['icons']['admin']);
-            }
+if(!$config['protect']['admin'] || (!$config['protect']['localhost_admin'] && (isset($_SERVER['SERVER_ADDR']) && $_SERVER['REMOTE_ADDR'] === $_SERVER['SERVER_ADDR'])) || !$config['login']['enabled'] || (isset($_SESSION['auth']) && $_SESSION['auth'] === true)) {
+    echo getMenuBtn(PathUtility::getPublicPath('admin'), 'admin_panel', $config['icons']['admin']);
+    echo getMenuBtn(PathUtility::getPublicPath('test'), 'testMenu', $config['icons']['admin']);
+}
 
-            echo getMenuBtn($fileRoot . 'gallery', 'gallery', $config['icons']['gallery']);
-            echo getMenuBtn($fileRoot . 'slideshow', 'slideshow', $config['icons']['slideshow']);
+echo getMenuBtn(PathUtility::getPublicPath('gallery'), 'gallery', $config['icons']['gallery']);
+echo getMenuBtn(PathUtility::getPublicPath('slideshow'), 'slideshow', $config['icons']['slideshow']);
 
-            if(!$config['protect']['index'] || (!$config['protect']['localhost_index'] && (isset($_SERVER['SERVER_ADDR']) && $_SERVER['REMOTE_ADDR'] === $_SERVER['SERVER_ADDR'])) || !$config['login']['enabled'] || (isset($_SESSION['auth']) && $_SESSION['auth'] === true)) {
-                echo getMenuBtn($fileRoot . 'chroma', 'chromaCapture', $config['icons']['chromaCapture']);
-            }
+if(!$config['protect']['index'] || (!$config['protect']['localhost_index'] && (isset($_SERVER['SERVER_ADDR']) && $_SERVER['REMOTE_ADDR'] === $_SERVER['SERVER_ADDR'])) || !$config['login']['enabled'] || (isset($_SESSION['auth']) && $_SESSION['auth'] === true)) {
+    echo getMenuBtn(PathUtility::getPublicPath('chroma'), 'chromaCapture', $config['icons']['chromaCapture']);
+}
 
-            if(!$config['protect']['manual'] || (!$config['protect']['localhost_manual'] && (isset($_SERVER['SERVER_ADDR']) && $_SERVER['REMOTE_ADDR'] === $_SERVER['SERVER_ADDR'])) || !$config['login']['enabled'] || (isset($_SESSION['auth']) && $_SESSION['auth'] === true)) {
-                echo getMenuBtn($fileRoot . 'faq', 'show_faq', $config['icons']['faq']);
-                echo getMenuBtn($fileRoot . 'manual', 'show_manual', $config['icons']['manual']);
-                echo getMenuBtn('https://t.me/PhotoboothGroup', 'telegram', $config['icons']['telegram']);
-            }
+if(!$config['protect']['manual'] || (!$config['protect']['localhost_manual'] && (isset($_SERVER['SERVER_ADDR']) && $_SERVER['REMOTE_ADDR'] === $_SERVER['SERVER_ADDR'])) || !$config['login']['enabled'] || (isset($_SESSION['auth']) && $_SESSION['auth'] === true)) {
+    echo getMenuBtn(PathUtility::getPublicPath('faq'), 'show_faq', $config['icons']['faq']);
+    echo getMenuBtn(PathUtility::getPublicPath('manual'), 'show_manual', $config['icons']['manual']);
+    echo getMenuBtn('https://t.me/PhotoboothGroup', 'telegram', $config['icons']['telegram']);
+}
 
-            // echo getMenuBtn("/", "reload", $config['icons']['refresh']);
+// echo getMenuBtn("/", "reload", $config['icons']['refresh']);
 
-            // reboot
-            if((isset($_SESSION['auth']) && $_SESSION['auth'] === true)) {
-                echo getMenuBtn('reboot-btn', 'reboot_button');
-            }
+// reboot
+if((isset($_SESSION['auth']) && $_SESSION['auth'] === true)) {
+    echo getMenuBtn('reboot-btn', 'reboot_button');
+}
 
-            // shutdown
-            if((isset($_SESSION['auth']) && $_SESSION['auth'] === true) || isset($_SESSION['rental'])) {
-                echo getMenuBtn('shutdown-btn', 'shutdown_button');
-            }
+// shutdown
+if((isset($_SESSION['auth']) && $_SESSION['auth'] === true) || isset($_SESSION['rental'])) {
+    echo getMenuBtn('shutdown-btn', 'shutdown_button');
+}
 
-            // logout
-            if((isset($_SESSION['auth']) && $_SESSION['auth'] === true) || isset($_SESSION['rental'])) {
-                echo getMenuBtn($fileRoot . 'login/logout.php', 'logout', $config['icons']['logout']);
-            }
+// logout
+if((isset($_SESSION['auth']) && $_SESSION['auth'] === true) || isset($_SESSION['rental'])) {
+    echo getMenuBtn(PathUtility::getPublicPath('login/logout.php'), 'logout', $config['icons']['logout']);
+}
 
-            ?>
+?>
     </div>
 </div>

--- a/manual/index.php
+++ b/manual/index.php
@@ -1,41 +1,42 @@
 <?php
 
-$fileRoot = '../';
-require_once($fileRoot . 'lib/boot.php');
+require_once '../lib/boot.php';
+
+use Photobooth\Utility\PathUtility;
 
 // Login / Authentication check
-if (
+if (!(
     !$config['login']['enabled'] ||
-    (!$config['protect']['localhost_manual'] && isset($_SERVER['SERVER_ADDR']) && $_SERVER['REMOTE_ADDR'] === $_SERVER['SERVER_ADDR']) ||
-    ((isset($_SESSION['auth']) && $_SESSION['auth'] === true) || !$config['protect']['manual'])
-) {
-    require_once($fileRoot . 'lib/configsetup.inc.php');
-} else {
-    header('location: ' . $fileRoot . 'login');
+    (!$config['protect']['localhost_manual'] && isset($_SERVER['SERVER_ADDR']) &&  $_SERVER['REMOTE_ADDR'] === $_SERVER['SERVER_ADDR']) ||
+    (isset($_SESSION['auth']) && $_SESSION['auth'] === true) || !$config['protect']['manual']
+)) {
+    header('location: ' . PathUtility::getPublicPath('login'));
     exit();
 }
 
+require_once PathUtility::getAbsolutePath('lib/configsetup.inc.php');
+
 $pageTitle = 'Manual';
-include($fileRoot . 'admin/components/head.admin.php');
-include($fileRoot . 'admin/helper/index.php');
-include($fileRoot . 'admin/inputs/index.php');
+include PathUtility::getAbsolutePath('admin/components/head.admin.php');
+include PathUtility::getAbsolutePath('admin/helper/index.php');
+include PathUtility::getAbsolutePath('admin/inputs/index.php');
 ?>
-	<div class="w-full h-full flex flex-col bg-brand-1 overflow-hidden fixed top-0 left-0">
-		<div class="max-w-[2000px] mx-auto w-full h-full flex flex-col">
+    <div class="w-full h-full flex flex-col bg-brand-1 overflow-hidden fixed top-0 left-0">
+       <div class="max-w-[2000px] mx-auto w-full h-full flex flex-col">
 
 
-			<!-- body -->
-			<div class="w-full h-full flex flex-1 flex-col md:flex-row mt-5 overflow-hidden">
-				<?php
-                    $sidebarHeadline = $pageTitle;
-include($fileRoot . 'admin/components/sidebar.php');
+            <!-- body -->
+            <div class="w-full h-full flex flex-1 flex-col md:flex-row mt-5 overflow-hidden">
+<?php
+$sidebarHeadline = $pageTitle;
+include PathUtility::getAbsolutePath('admin/components/sidebar.php');
 ?>
-				<div class="flex flex-1 flex-col bg-content-1 rounded-xl ml-5 mr-5 mb-5 md:ml-0 overflow-hidden">
+                <div class="flex flex-1 flex-col bg-content-1 rounded-xl ml-5 mr-5 mb-5 md:ml-0 overflow-hidden">
 
-					<div class="w-full h-full flex flex-col" autocomplete="off">
-						<div class="adminContent w-full flex flex-1 flex-col py-5 overflow-x-hidden overflow-y-auto">
-							<form>
-								<?php
+                    <div class="w-full h-full flex flex-col" autocomplete="off">
+                        <div class="adminContent w-full flex flex-1 flex-col py-5 overflow-x-hidden overflow-y-auto">
+                            <form>
+                                <?php
                     $i = 0;
 foreach($configsetup as $panel => $fields) {
     $panelHidden = 'visible';
@@ -125,23 +126,20 @@ foreach($configsetup as $panel => $fields) {
     $i++;
 }
 ?>
-								
-								<div class="py-4 px-4 lg:px-8">
-									<a href="<?=$fileRoot?>faq/" class="flex items-center hover:underline hover:text-brand-1 mb-2" title="FAQ" target="newwin"><span data-i18n="show_faq"></span> <i class="ml-2 <?php echo $config['icons']['faq']; ?>"></i></a>
-									<a href="https://photoboothproject.github.io" target="_blank" class="flex items-center hover:underline hover:text-brand-1"><span data-i18n="show_wiki"></span></a>
-								</div>
-							</form>
-						</div>
-					</div>
 
-				</div>
-			</div>
+                                <div class="py-4 px-4 lg:px-8">
+                                    <a href="<?=PathUtility::getPublicPath('faq')?>" class="flex items-center hover:underline hover:text-brand-1 mb-2" title="FAQ" target="newwin"><span data-i18n="show_faq"></span> <i class="ml-2 <?php echo $config['icons']['faq']; ?>"></i></a>
+                                    <a href="https://photoboothproject.github.io" target="_blank" class="flex items-center hover:underline hover:text-brand-1"><span data-i18n="show_wiki"></span></a>
+                                </div>
+                            </form>
+                        </div>
+                    </div>
 
-		</div>
-	</div>
+                </div>
+            </div>
 
-
+        </div>
+    </div>
 
 <?php
-    include($fileRoot . 'admin/components/footer.admin.php');
-?>
+    include PathUtility::getAbsolutePath('admin/components/footer.admin.php');

--- a/slideshow/index.php
+++ b/slideshow/index.php
@@ -1,8 +1,8 @@
 <?php
 
-$fileRoot = '../';
+require_once '../lib/boot.php';
 
-require_once($fileRoot . 'lib/boot.php');
+use Photobooth\Utility\PathUtility;
 
 $pageTitle = $config['ui']['branding'] . ' Slideshow';
 $mainStyle = $config['ui']['style'] . '_style.css';
@@ -12,23 +12,20 @@ $remoteBuzzer = false;
 $chromaKeying = false;
 $GALLERY_FOOTER = false;
 
-include($fileRoot . 'template/components/main.head.php');
+include PathUtility::getAbsolutePath('template/components/main.head.php');
 
 ?>
-
 <body class="deselect">
-	<div id="wrapper">
+    <div id="wrapper">
         <div id="gallery" class="gallery">
-	        <div class="gallery__inner">
-		        <div class="gallery__header">
-			        <h1><span data-i18n="slideshow"></span></h1>
-		        </div>
-                <?php include($fileRoot . 'template/components/gal.images.php'); ?>
+            <div class="gallery__inner">
+                <div class="gallery__header">
+                    <h1><span data-i18n="slideshow"></span></h1>
+                </div>
+                <?php include PathUtility::getAbsolutePath('template/components/gal.images.php'); ?>
         </div>
-	</div>
-
-    <?php include($fileRoot . 'template/components/main.footer.php'); ?>
-
-	<script type="text/javascript" src="<?=$fileRoot?>resources/js/slideshow.js?v=<?php echo $config['photobooth']['version']; ?>"></script>
+    </div>
+    <?php include PathUtility::getAbsolutePath('template/components/main.footer.php'); ?>
+    <script type="text/javascript" src="<?=PathUtility::getPublicPath()?>resources/js/slideshow.js?v=<?php echo $config['photobooth']['version']; ?>"></script>
 </body>
 </html>

--- a/template/classic.template.php
+++ b/template/classic.template.php
@@ -1,6 +1,11 @@
+<?php
+
+use Photobooth\Utility\PathUtility;
+
+?>
 <!-- Start Page -->
 <div class="stages <?php echo $uiShape; ?> rotarygroup noborder" id="start">
-    <?php include 'components/start.logo.php'; ?>
+    <?php include PathUtility::getAbsolutePath('template/components/start.logo.php'); ?>
     <div class="startInner <?php echo $uiShape; ?> noborder">
         <?php if ($config['event']['enabled']): ?>
         <div class="names">
@@ -47,7 +52,7 @@
         </div>
         <?php endif; ?>
 
-        <?php include 'components/actionBtn.php'; ?>
+        <?php include PathUtility::getAbsolutePath('template/components/actionBtn.php'); ?>
     </div>
 
     <?php if ($config['ui']['show_fork']): ?>

--- a/template/classic_rounded.template.php
+++ b/template/classic_rounded.template.php
@@ -1,3 +1,5 @@
 <?php
 
-include 'classic.template.php';
+use Photobooth\Utility\PathUtility;
+
+include PathUtility::getAbsolutePath('template/classic.template.php');

--- a/template/components/gal.images.php
+++ b/template/components/gal.images.php
@@ -1,5 +1,7 @@
 <?php
 
+use Photobooth\Utility\PathUtility;
+
 if (empty($imagelist)) {
     echo '<h1 style="text-align:center" data-i18n="gallery_no_image"></h1>' . "\n";
 } else {
@@ -20,8 +22,8 @@ if (empty($imagelist)) {
                 }
             }
 
-            $filename_photo = $fileRoot . $config['folders']['data'] . DIRECTORY_SEPARATOR . $config['folders']['images'] . DIRECTORY_SEPARATOR . $image;
-            $filename_thumb = $fileRoot . $config['folders']['data'] . DIRECTORY_SEPARATOR . $config['folders']['thumbs'] . DIRECTORY_SEPARATOR . $image;
+            $filename_photo = PathUtility::getAbsolutePath($config['folders']['data'] . DIRECTORY_SEPARATOR . $config['folders']['images'] . DIRECTORY_SEPARATOR . $image);
+            $filename_thumb = PathUtility::getAbsolutePath($config['folders']['data'] . DIRECTORY_SEPARATOR . $config['folders']['thumbs'] . DIRECTORY_SEPARATOR . $image);
 
             $imageinfo = @getimagesize($filename_photo);
             $imageinfoThumb = @getimagesize($filename_thumb);
@@ -30,11 +32,11 @@ if (empty($imagelist)) {
                 if (!is_array($imageinfoThumb)) {
                     $imageinfoThumb = $imageinfo;
                 }
-                echo '<a href="' . $filename_photo . '" class="gallery__img rotaryfocus" data-size="' . $imageinfo[0] . 'x' . $imageinfo[1] . '"';
+                echo '<a href="' . PathUtility::getPublicPath($filename_photo) . '" class="gallery__img rotaryfocus" data-size="' . $imageinfo[0] . 'x' . $imageinfo[1] . '"';
                 echo ' data-pswp-width="' . $imageinfo[0] . '" data-pswp-height="' . $imageinfo[1] . '"';
-                echo ' data-med="' . $filename_thumb . '" data-med-size="' . $imageinfoThumb[0] . 'x' . $imageinfoThumb[1] . '">' . "\n";
+                echo ' data-med="' . PathUtility::getPublicPath($filename_thumb) . '" data-med-size="' . $imageinfoThumb[0] . 'x' . $imageinfoThumb[1] . '">' . "\n";
                 echo '<figure class="' . $uiShape . '">' . "\n";
-                echo '<img class="' . $uiShape . '" src="' . $filename_thumb . '" alt="' . $image . '" />' . "\n";
+                echo '<img class="' . $uiShape . '" src="' . PathUtility::getPublicPath($filename_thumb) . '" alt="' . $image . '" />' . "\n";
                 if ($config['gallery']['figcaption']) {
                     echo '<figcaption class="' . $uiShape . '">' . $date . '</figcaption>' . "\n";
                 }

--- a/template/components/helper/index.php
+++ b/template/components/helper/index.php
@@ -1,3 +1,5 @@
 <?php
 
-include 'boothButton.php';
+use Photobooth\Utility\PathUtility;
+
+include PathUtility::getAbsolutePath('template/components/helper/boothButton.php');

--- a/template/components/main.footer.php
+++ b/template/components/main.footer.php
@@ -1,30 +1,35 @@
-<script src="<?= $fileRoot ?>node_modules/whatwg-fetch/dist/fetch.umd.js"></script>
-<script type="text/javascript" src="<?= $fileRoot ?>api/config.php?v=<?= $config['photobooth']['version'] ?>"></script>
-<script type="text/javascript" src="<?= $fileRoot ?>resources/js/tools.js?v=<?= $config['photobooth']['version'] ?>"></script>
-<script type="text/javascript" src="<?= $fileRoot ?>resources/js/theme.js?v=<?= $config['photobooth']['version'] ?>"></script>
-<script src="<?= $fileRoot ?>node_modules/@andreasremdt/simple-translator/dist/umd/translator.min.js"></script>
-<script type="text/javascript" src="<?= $fileRoot ?>resources/js/i18n.js?v=<?= $config['photobooth']['version'] ?>"></script>
+<?php
+
+use Photobooth\Utility\PathUtility;
+
+?>
+
+<script type="text/javascript" src="<?=PathUtility::getPublicPath()?>node_modules/whatwg-fetch/dist/fetch.umd.js"></script>
+<script type="text/javascript" src="<?=PathUtility::getPublicPath()?>api/config.php?v=<?= $config['photobooth']['version'] ?>"></script>
+<script type="text/javascript" src="<?=PathUtility::getPublicPath()?>resources/js/tools.js?v=<?= $config['photobooth']['version'] ?>"></script>
+<script type="text/javascript" src="<?=PathUtility::getPublicPath()?>resources/js/theme.js?v=<?= $config['photobooth']['version'] ?>"></script>
+<script type="text/javascript" src="<?=PathUtility::getPublicPath()?>node_modules/@andreasremdt/simple-translator/dist/umd/translator.min.js"></script>
+<script type="text/javascript" src="<?=PathUtility::getPublicPath()?>resources/js/i18n.js?v=<?= $config['photobooth']['version'] ?>"></script>
 
 <?php
+
 if ($remoteBuzzer) {
-    echo '<script type="text/javascript" src="' . $fileRoot . 'node_modules/socket.io-client/dist/socket.io.min.js"></script>' . "\n";
-    echo '<script type="text/javascript" src="' . $fileRoot . 'resources/js/remotebuzzer_client.js?v=' . $config['photobooth']['version'] . '"></script>' . "\n";
+    echo '<script type="text/javascript" src="' . PathUtility::getPublicPath() . 'node_modules/socket.io-client/dist/socket.io.min.js"></script>' . "\n";
+    echo '<script type="text/javascript" src="' . PathUtility::getPublicPath() . 'resources/js/remotebuzzer_client.js?v=' . $config['photobooth']['version'] . '"></script>' . "\n";
 }
 
 if ($photoswipe) {
-    echo '<script type="text/javascript" src="' . $fileRoot . 'node_modules/photoswipe/dist/umd/photoswipe.umd.min.js"></script>' . "\n";
-    echo '<script type="text/javascript" src="' . $fileRoot . 'node_modules/photoswipe/dist/umd/photoswipe-lightbox.umd.min.js"></script>' . "\n";
-    echo '<script type="text/javascript" src="' . $fileRoot . 'resources/js/photoswipe.js?v=' . $config['photobooth']['version'] . '"></script>' . "\n";
+    echo '<script type="text/javascript" src="' . PathUtility::getPublicPath() . 'node_modules/photoswipe/dist/umd/photoswipe.umd.min.js"></script>' . "\n";
+    echo '<script type="text/javascript" src="' . PathUtility::getPublicPath() . 'node_modules/photoswipe/dist/umd/photoswipe-lightbox.umd.min.js"></script>' . "\n";
+    echo '<script type="text/javascript" src="' . PathUtility::getPublicPath() . 'resources/js/photoswipe.js?v=' . $config['photobooth']['version'] . '"></script>' . "\n";
 }
 
 if ($chromaKeying) {
     if ($config['keying']['variant'] === 'marvinj') {
-        echo '<script type="text/javascript" src="' . $fileRoot . 'node_modules/marvinj/marvinj/release/marvinj-1.0.js"></script>' . "\n";
+        echo '<script type="text/javascript" src="' . PathUtility::getPublicPath() . 'node_modules/marvinj/marvinj/release/marvinj-1.0.js"></script>' . "\n";
     } else {
-        echo '<script type="text/javascript" src="' . $fileRoot . 'vendor/Seriously/seriously.js"></script>' . "\n";
-        echo '<script type="text/javascript" src="' . $fileRoot . 'vendor/Seriously/effects/seriously.chroma.js"></script>' . "\n";
+        echo '<script type="text/javascript" src="' . PathUtility::getPublicPath() . 'vendor/Seriously/seriously.js"></script>' . "\n";
+        echo '<script type="text/javascript" src="' . PathUtility::getPublicPath() . 'vendor/Seriously/effects/seriously.chroma.js"></script>' . "\n";
     }
-    echo '<script type="text/javascript" src="' . $fileRoot . 'resources/js/chromakeying.js?v=' . $config['photobooth']['version'] . '"></script>' . "\n";
+    echo '<script type="text/javascript" src="' . PathUtility::getPublicPath() . 'resources/js/chromakeying.js?v=' . $config['photobooth']['version'] . '"></script>' . "\n";
 }
-
-?>

--- a/template/components/main.head.php
+++ b/template/components/main.head.php
@@ -1,6 +1,10 @@
 <?php
-include 'main.defaults.php'; ?>
 
+use Photobooth\Utility\PathUtility;
+
+include PathUtility::getAbsolutePath('template/components/main.defaults.php');
+
+?>
 <!DOCTYPE html>
 <html>
 <head>
@@ -13,34 +17,33 @@ include 'main.defaults.php'; ?>
     <title><?= $pageTitle ?></title>
 
     <!-- Favicon + Android/iPhone Icons -->
-    <link rel="apple-touch-icon" sizes="180x180" href="<?= $fileRoot ?>resources/img/apple-touch-icon.png">
-    <link rel="icon" type="image/png" sizes="32x32" href="<?= $fileRoot ?>resources/img/favicon-32x32.png">
-    <link rel="icon" type="image/png" sizes="16x16" href="<?= $fileRoot ?>resources/img/favicon-16x16.png">
-    <link rel="manifest" href="<?= $fileRoot ?>resources/img/site.webmanifest">
-    <link rel="mask-icon" href="<?= $fileRoot ?>resources/img/safari-pinned-tab.svg" color="#5bbad5">
+    <link rel="apple-touch-icon" sizes="180x180" href="<?=PathUtility::getPublicPath()?>resources/img/apple-touch-icon.png">
+    <link rel="icon" type="image/png" sizes="32x32" href="<?=PathUtility::getPublicPath()?>resources/img/favicon-32x32.png">
+    <link rel="icon" type="image/png" sizes="16x16" href="<?=PathUtility::getPublicPath()?>resources/img/favicon-16x16.png">
+    <link rel="manifest" href="<?=PathUtility::getPublicPath()?>resources/img/site.webmanifest">
+    <link rel="mask-icon" href="<?=PathUtility::getPublicPath()?>resources/img/safari-pinned-tab.svg" color="#5bbad5">
 
     <!-- Fullscreen Mode on old iOS-Devices when starting photobooth from homescreen -->
     <meta name="apple-mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-status-bar-style" content="black" />
 
-    <link rel="stylesheet" href="<?= $fileRoot ?>node_modules/normalize.css/normalize.css" />
-    <link rel="stylesheet" href="<?= $fileRoot ?>node_modules/font-awesome/css/font-awesome.css" />
-    <link rel="stylesheet" href="<?= $fileRoot ?>node_modules/material-icons/iconfont/material-icons.css">
-    <link rel="stylesheet" href="<?= $fileRoot ?>node_modules/material-icons/css/material-icons.css">
-    <link rel="stylesheet" href="<?= $fileRoot ?>resources/css/tailwind.css?v=<?= $config['photobooth']['version'] ?>"/>
+    <link rel="stylesheet" href="<?=PathUtility::getPublicPath()?>node_modules/normalize.css/normalize.css" />
+    <link rel="stylesheet" href="<?=PathUtility::getPublicPath()?>node_modules/font-awesome/css/font-awesome.css" />
+    <link rel="stylesheet" href="<?=PathUtility::getPublicPath()?>node_modules/material-icons/iconfont/material-icons.css">
+    <link rel="stylesheet" href="<?=PathUtility::getPublicPath()?>node_modules/material-icons/css/material-icons.css">
+    <link rel="stylesheet" href="<?=PathUtility::getPublicPath()?>resources/css/tailwind.css?v=<?= $config['photobooth']['version'] ?>"/>
 
     <?php
-    echo '<link rel="stylesheet" href="' . $fileRoot . 'resources/css/' . $mainStyle . '?v=' . $config['photobooth']['version'] . '"/>';
+    echo '<link rel="stylesheet" href="' . PathUtility::getPublicPath() . 'resources/css/' . $mainStyle . '?v=' . $config['photobooth']['version'] . '"/>';
 if ($photoswipe) {
-    echo '<link rel="stylesheet" href="' . $fileRoot . 'node_modules/photoswipe/dist/photoswipe.css"/>' . "\n";
+    echo '<link rel="stylesheet" href="' . PathUtility::getPublicPath() . 'node_modules/photoswipe/dist/photoswipe.css"/>' . "\n";
     if ($config['gallery']['bottom_bar']) {
-        echo '<link rel="stylesheet" href="' . $fileRoot . 'resources/css/photoswipe-bottom.css?v=' . $config['photobooth']['version'] . '"/>' . "\n";
+        echo '<link rel="stylesheet" href="' . PathUtility::getPublicPath() . 'resources/css/photoswipe-bottom.css?v=' . $config['photobooth']['version'] . '"/>' . "\n";
     }
 }
-if (is_file($fileRoot . 'private/overrides.css')) {
-    echo '<link rel="stylesheet" href="' . $fileRoot . 'private/overrides.css?v=' . $config['photobooth']['version'] . '"/>' . "\n";
+if (is_file(PathUtility::getAbsolutePath('private/overrides.css'))) {
+    echo '<link rel="stylesheet" href="' . PathUtility::getPublicPath() . 'private/overrides.css?v=' . $config['photobooth']['version'] . '"/>' . "\n";
 }
 ?>
-
-    <script type="text/javascript" src="<?= $fileRoot ?>node_modules/jquery/dist/jquery.min.js"></script>
+    <script type="text/javascript" src="<?= PathUtility::getPublicPath() ?>node_modules/jquery/dist/jquery.min.js"></script>
 </head>

--- a/template/components/start.logo.php
+++ b/template/components/start.logo.php
@@ -16,7 +16,7 @@ if ($config['logo']['enabled']) {
     echo '<div id="pblogo" class="' .
         $logoClasses .
         ' pblogo--div">
-		<img class="w-full h-full object-contain pblogo--img" src="' .
+        <img class="w-full h-full object-contain pblogo--img" src="' .
         $config['logo']['path'] .
         '" alt="logo">
 </div>';

--- a/template/components/start.results.php
+++ b/template/components/start.results.php
@@ -1,6 +1,11 @@
+<?php
+
+use Photobooth\Utility\PathUtility;
+
+?>
 <div class="stages rotarygroup" id="result">
     <div class="resultInner hidden">
-    <?php include 'resultsBtn.php'; ?>
+    <?php include PathUtility::getAbsolutePath('template/components/resultsBtn.php'); ?>
     </div>
 
     <?php if ($config['qr']['enabled']): ?>

--- a/template/gallery.template.php
+++ b/template/gallery.template.php
@@ -1,17 +1,20 @@
+<?php
+
+use Photobooth\Utility\PathUtility;
+
+?>
 <div id="gallery" class="gallery rotarygroup">
     <div class="gallery__inner">
         <div class="gallery__header">
             <h1><span data-i18n="gallery"></span></h1>
             <a href="#" class="<?php echo $btnClass; ?> gallery__close close_gal rotaryfocus"><i class="<?php echo $config['icons']['close']; ?>"></i></a>
         </div>
-
-        <?php
-        include 'components/gal.images.php';
-
-            if ($GALLERY_FOOTER === true && $config['gallery']['action_footer'] === true) {
-                include 'components/gal.btnFooter.php';
-            }
-            ?>
+<?php
+include PathUtility::getAbsolutePath('template/components/gal.images.php');
+if ($GALLERY_FOOTER === true && $config['gallery']['action_footer'] === true) {
+    include PathUtility::getAbsolutePath('template/components/gal.btnFooter.php');
+}
+?>
     </div>
 </div>
 

--- a/template/modern.template.php
+++ b/template/modern.template.php
@@ -1,6 +1,11 @@
+<?php
+
+use Photobooth\Utility\PathUtility;
+
+?>
 <!-- Start Page -->
 <div class="stages <?php echo $uiShape; ?> noborder" id="start">
-    <?php include 'components/start.logo.php'; ?>
+    <?php include PathUtility::getAbsolutePath('template/components/start.logo.php'); ?>
     <div class="startInner <?php echo $uiShape; ?> noborder">
         <div class="divaussen">
             <div class="divinnen">
@@ -51,7 +56,7 @@
                     </div>
                     <?php endif; ?>
                     <div class="rotarygroup">
-                        <?php include 'components/actionBtn.php'; ?>
+                        <?php include PathUtility::getAbsolutePath('template/components/actionBtn.php'); ?>
                     </div>
                 </div>
             </div>

--- a/template/modern_squared.template.php
+++ b/template/modern_squared.template.php
@@ -1,3 +1,5 @@
 <?php
 
-include 'modern.template.php';
+use Photobooth\Utility\PathUtility;
+
+include PathUtility::getAbsolutePath('template/modern.template.php');

--- a/test/chroma.php
+++ b/test/chroma.php
@@ -1,7 +1,8 @@
 <?php
 
-$fileRoot = '../';
-require_once $fileRoot . 'lib/boot.php';
+require_once '../lib/boot.php';
+
+use Photobooth\Utility\PathUtility;
 
 $pageTitle = $config['ui']['branding'] . ' Chroma-Preview Test';
 $mainStyle = 'test_preview.css';
@@ -9,7 +10,7 @@ $photoswipe = false;
 $remoteBuzzer = false;
 $chromaKeying = false;
 
-include($fileRoot . 'template/components/main.head.php');
+include PathUtility::getAbsolutePath('template/components/main.head.php');
 ?>
 
 <body>
@@ -22,7 +23,7 @@ include($fileRoot . 'template/components/main.head.php');
             <span data-i18n="no_preview"></span>
         </div>
 
-		<div class="buttonbar">
+        <div class="buttonbar">
             <a href="#" class="<?php echo $btnClass; ?> startPreview"><span data-i18n="startPreview"></span></a>
             <a href="#" class="<?php echo $btnClass; ?> stopPreview"><span data-i18n="stopPreview"></span></a><br>
             <label for="chromaImage">Chroma Image:</label>
@@ -34,15 +35,15 @@ include($fileRoot . 'template/components/main.head.php');
             <label for="chromaBlend">Blend:</label>
             <input id="chromaBlend" type="number" value="0.1"/>
             <a href="#" class="<?php echo $btnClass; ?> setChroma"><span data-i18n="set">Set</span></a>
-            <a href="<?php echo $fileRoot . 'test'; ?>" class="<?php echo $btnClass; ?> backBtn"><span data-i18n="back"></span></a>
+            <a href="<?php echo PathUtility::getPublicPath('test'); ?>" class="<?php echo $btnClass; ?> backBtn"><span data-i18n="back"></span></a>
         </div>
     </div>
 
-    <?php include($fileRoot . 'template/components/main.footer.php'); ?>
+    <?php include PathUtility::getAbsolutePath('template/components/main.footer.php'); ?>
 
-    <script type="text/javascript" src="<?=$fileRoot?>resources/js/preview.js?v=<?php echo $config['photobooth']['version']; ?>"></script>
-    <script type="text/javascript" src="<?=$fileRoot?>resources/js/test_preview.js?v=<?php echo $config['photobooth']['version']; ?>"></script>
-    <script type="text/javascript" src="<?=$fileRoot?>resources/js/test_chroma.js?v=<?php echo $config['photobooth']['version']; ?>"></script>
+    <script type="text/javascript" src="<?=PathUtility::getPublicPath()?>resources/js/preview.js?v=<?php echo $config['photobooth']['version']; ?>"></script>
+    <script type="text/javascript" src="<?=PathUtility::getPublicPath()?>resources/js/test_preview.js?v=<?php echo $config['photobooth']['version']; ?>"></script>
+    <script type="text/javascript" src="<?=PathUtility::getPublicPath()?>resources/js/test_chroma.js?v=<?php echo $config['photobooth']['version']; ?>"></script>
 
 </body>
 </html>

--- a/test/collage.php
+++ b/test/collage.php
@@ -1,13 +1,12 @@
 <?php
 
-$fileRoot = '../';
-require_once $fileRoot . 'lib/boot.php';
+require_once '../lib/boot.php';
 
 use Photobooth\Collage;
 use Photobooth\Image;
+use Photobooth\Utility\PathUtility;
 
-$demoPath = __DIR__ . DIRECTORY_SEPARATOR . '..' . DIRECTORY_SEPARATOR . 'resources/img/demo';
-$demoFolder = realpath($demoPath);
+$demoFolder = PathUtility::getAbsolutePath('resources/img/demo');
 $devImg = array_diff(scandir($demoFolder), ['.', '..']);
 
 $demoImages = [];

--- a/test/healthcheck.php
+++ b/test/healthcheck.php
@@ -1,18 +1,18 @@
 <?php
 
-$fileRoot = '../';
-require_once $fileRoot . 'lib/boot.php';
+require_once '../lib/boot.php';
 
 use Photobooth\HealthCheck;
+use Photobooth\Utility\PathUtility;
 
 $pageTitle = $config['ui']['branding'] . ' Health Check';
 $remoteBuzzer = false;
 $photoswipe = false;
 $chromaKeying = false;
 
-include($fileRoot . 'admin/components/head.admin.php');
-include($fileRoot . 'admin/helper/index.php');
-include($fileRoot . 'admin/inputs/index.php');
+include PathUtility::getAbsolutePath('admin/components/head.admin.php');
+include PathUtility::getAbsolutePath('admin/helper/index.php');
+include PathUtility::getAbsolutePath('admin/inputs/index.php');
 
 $healthCheck = new HealthCheck();
 $healthData = '<h3 class="font-bold uppercase underline pb-2"><span data-i18n="healthStatus"></span></h3>';
@@ -32,25 +32,25 @@ $healthData .= $healthCheck->healthStatus ? '<p><b><span data-i18n="healthGood">
 ?>
 
 <div class="w-full h-full grid place-items-center fixed bg-brand-2 overflow-x-hidden overflow-y-auto">
-		<div class="w-full flex items-center justify-center flex-col px-6 py-12">
-			<div class="w-full max-w-4xl h-144 rounded-lg bg-white flex flex-col shadow-xl">
-				<div class="p-4 md:p-8">
-					<?php
+        <div class="w-full flex items-center justify-center flex-col px-6 py-12">
+            <div class="w-full max-w-4xl h-144 rounded-lg bg-white flex flex-col shadow-xl">
+                <div class="p-4 md:p-8">
+                    <?php
                     $healthCheckBg = $healthCheck->healthStatus ? 'bg-green-500' : 'bg-red-500';
 echo '<div class="w-full p-5 mx-auto mt-2 rounded-lg ' . $healthCheckBg . ' text-white text-center">';
 echo $healthData;
 echo '</div>';
 echo '<div class="w-full max-w-md p-5 mx-auto mt-2">';
-echo getMenuBtn($fileRoot . 'test', 'back', 'fa fa-chevron-left');
+echo getMenuBtn(PathUtility::getPublicPath('test'), 'back', 'fa fa-chevron-left');
 echo '</div>';
 ?>
-				</div>
-			</div>
-		</div>
-	</div>
+                </div>
+            </div>
+        </div>
+    </div>
 
-    <?php
-    include $fileRoot . 'template/components/main.footer.php';
+<?php
+    include PathUtility::getAbsolutePath('template/components/main.footer.php');
 ?>
 
 </body>

--- a/test/index.php
+++ b/test/index.php
@@ -1,11 +1,12 @@
 <?php
 
-$fileRoot = '../';
-require_once $fileRoot . 'lib/boot.php';
+require_once '../lib/boot.php';
+
+use Photobooth\Utility\PathUtility;
 
 $pageTitle = 'Tests';
-include $fileRoot . 'admin/components/head.admin.php';
-include $fileRoot . 'admin/helper/index.php';
+include PathUtility::getAbsolutePath('admin/components/head.admin.php');
+include PathUtility::getAbsolutePath('admin/helper/index.php');
 
 $labelClass = 'w-full flex flex-col mb-1';
 $inputClass = 'w-full h-10 border border-solid border-gray-300 focus:border-brand-1 rounded-md px-3 mt-auto';
@@ -14,36 +15,38 @@ $btnClass =
 ?>
 
 <body>
-	<div class="w-full h-screen grid place-items-center absolute bg-brand-2 px-6 py-12 overflow-x-hidden overflow-y-auto">
-		<div class="w-full flex items-center justify-center flex-col">
-			<div class="w-full max-w-xl rounded-lg py-8 bg-white flex flex-col shadow-xl relative">
-				<div class="px-4">
-					<h1 class="text-2xl font-bold text-center mb-6 border-solid border-b border-gray-200 pb-4 text-brand-1">
-						<span data-i18n="testMenu"></span>
-					</h1>
-				</div>
-				<div class="w-12 h-12 bg-white absolute right-4 top-4 rounded-b-l-lg shadow-xls flex items-center justify-center text-brand-1 cursor-pointer">
-					<a href="<?= $fileRoot . 'login' ?>" >
-						<i class="!text-2xl <?php echo $config['icons']['close']; ?>"></i>
-					</a>
-				</div>
+    <div class="w-full h-screen grid place-items-center absolute bg-brand-2 px-6 py-12 overflow-x-hidden overflow-y-auto">
+        <div class="w-full flex items-center justify-center flex-col">
+            <div class="w-full max-w-xl rounded-lg py-8 bg-white flex flex-col shadow-xl relative">
+                <div class="px-4">
+                    <h1 class="text-2xl font-bold text-center mb-6 border-solid border-b border-gray-200 pb-4 text-brand-1">
+                        <span data-i18n="testMenu"></span>
+                    </h1>
+                </div>
+                <div class="w-12 h-12 bg-white absolute right-4 top-4 rounded-b-l-lg shadow-xls flex items-center justify-center text-brand-1 cursor-pointer">
+                    <a href="<?=PathUtility::getPublicPath('login')?>" >
+                        <i class="!text-2xl <?php echo $config['icons']['close']; ?>"></i>
+                    </a>
+                </div>
 
-				<div class="grid grid-cols-1 md:grid-cols-2 gap-4 px-4 ">
-				<?php
-                echo getMenuBtn('../test/healthcheck.php', 'healthCheck', '');
-echo getMenuBtn('../test/phpinfo.php', 'phpinfo', '');
-echo getMenuBtn('../test/photo.php', 'pictureTest', '');
-echo getMenuBtn('../test/collage.php', 'collageTest', '');
-echo getMenuBtn('../test/preview.php', 'previewTest', '');
-echo getMenuBtn('../test/chroma.php', 'chromaPreviewTest', '');
-echo getMenuBtn('../test/trigger.php', 'remotebuzzerGetTrigger', '');
+                <div class="grid grid-cols-1 md:grid-cols-2 gap-4 px-4 ">
+<?php
+
+echo getMenuBtn(PathUtility::getPublicPath('test/healthcheck.php'), 'healthCheck', '');
+echo getMenuBtn(PathUtility::getPublicPath('test/phpinfo.php'), 'phpinfo', '');
+echo getMenuBtn(PathUtility::getPublicPath('test/photo.php'), 'pictureTest', '');
+echo getMenuBtn(PathUtility::getPublicPath('test/collage.php'), 'collageTest', '');
+echo getMenuBtn(PathUtility::getPublicPath('test/preview.php'), 'previewTest', '');
+echo getMenuBtn(PathUtility::getPublicPath('test/chroma.php'), 'chromaPreviewTest', '');
+echo getMenuBtn(PathUtility::getPublicPath('test/trigger.php'), 'remotebuzzerGetTrigger', '');
+
 ?>
-				</div>
+                </div>
 
-			</div>
-		</div>
-	</div>
+            </div>
+        </div>
+    </div>
 
 <?php
-include $fileRoot . 'admin/components/footer.admin.php';
+include PathUtility::getAbsolutePath('admin/components/footer.admin.php');
 ?>

--- a/test/photo.php
+++ b/test/photo.php
@@ -1,25 +1,20 @@
 <?php
 
-$fileRoot = '../';
-require_once $fileRoot . 'lib/boot.php';
+require_once '../lib/boot.php';
 
 use Photobooth\ImageFilter;
 use Photobooth\Image;
-
-$demoPath = __DIR__ . DIRECTORY_SEPARATOR . '..' . DIRECTORY_SEPARATOR . 'resources/img/demo';
-$demoFolder = realpath($demoPath);
-$devImg = array_diff(scandir($demoFolder), ['.', '..']);
-$demoImage = $devImg[array_rand($devImg)];
+use Photobooth\Utility\ImageUtility;
 
 $imageHandler = new Image();
 $imageHandler->debugLevel = $config['dev']['loglevel'];
 $imageHandler->imageModified = false;
 
-$imageResource = $imageHandler->createFromImage($demoFolder . DIRECTORY_SEPARATOR . $demoImage);
+$imageResource = $imageHandler->createFromImage(ImageUtility::getRandomImageFromPath('resources/img/demo'));
 if (!$imageResource) {
     throw new Exception('Error creating image resource.');
 }
-$imageHandler->framePath = str_starts_with($config['picture']['frame'], 'http') ? $config['picture']['frame'] : $_SERVER['DOCUMENT_ROOT'] . $config['picture']['frame'];
+$imageHandler->framePath = $config['picture']['frame'];
 
 if ($config['picture']['flip'] !== 'off') {
     try {

--- a/test/preview.php
+++ b/test/preview.php
@@ -1,7 +1,8 @@
 <?php
 
-$fileRoot = '../';
-require_once $fileRoot . 'lib/boot.php';
+require_once '../lib/boot.php';
+
+use Photobooth\Utility\PathUtility;
 
 $pageTitle = $config['ui']['branding'] . ' Preview-Test';
 $mainStyle = 'test_preview.css';
@@ -9,7 +10,7 @@ $photoswipe = false;
 $remoteBuzzer = false;
 $chromaKeying = false;
 
-include($fileRoot . 'template/components/main.head.php');
+include PathUtility::getAbsolutePath('template/components/main.head.php');
 ?>
 
 <body>
@@ -28,26 +29,26 @@ include($fileRoot . 'template/components/main.head.php');
             <span data-i18n="no_preview"></span>
         </div>
 
-		<div class="buttonbar">
-			<a href="#" class="<?php echo $btnClass; ?> startPreview"><span data-i18n="startPreview"></span></a>
-			<a href="#" class="<?php echo $btnClass; ?> stopPreview"><span data-i18n="stopPreview"></span></a>
-			<?php if ($config['preview']['showFrame'] && !empty($config['picture']['htmlframe'])): ?>
-			<a href="#" class="<?php echo $btnClass; ?> showPictureFrame"><span data-i18n="showPictureFrame"></span></a>
-			<?php endif; ?>
-			<?php if ($config['preview']['showFrame'] && !empty($config['collage']['htmlframe'])): ?>
-			<a href="#" class="<?php echo $btnClass; ?> showCollageFrame"><span data-i18n="showCollageFrame"></span></a>
-			<?php endif; ?>
-			<?php if ($config['preview']['showFrame'] && !empty($config['picture']['htmlframe']) || $config['preview']['showFrame'] && !empty($config['collage']['htmlframe'])): ?>
-			<a href="#" class="<?php echo $btnClass; ?> hideFrame"><span data-i18n="hideFrame"></span></a>
-			<?php endif; ?>
-			<a href="<?php echo $fileRoot . 'test'; ?>" class="<?php echo $btnClass; ?> backBtn"><span data-i18n="back"></span></a>
+        <div class="buttonbar">
+            <a href="#" class="<?php echo $btnClass; ?> startPreview"><span data-i18n="startPreview"></span></a>
+            <a href="#" class="<?php echo $btnClass; ?> stopPreview"><span data-i18n="stopPreview"></span></a>
+            <?php if ($config['preview']['showFrame'] && !empty($config['picture']['htmlframe'])): ?>
+            <a href="#" class="<?php echo $btnClass; ?> showPictureFrame"><span data-i18n="showPictureFrame"></span></a>
+            <?php endif; ?>
+            <?php if ($config['preview']['showFrame'] && !empty($config['collage']['htmlframe'])): ?>
+            <a href="#" class="<?php echo $btnClass; ?> showCollageFrame"><span data-i18n="showCollageFrame"></span></a>
+            <?php endif; ?>
+            <?php if ($config['preview']['showFrame'] && !empty($config['picture']['htmlframe']) || $config['preview']['showFrame'] && !empty($config['collage']['htmlframe'])): ?>
+            <a href="#" class="<?php echo $btnClass; ?> hideFrame"><span data-i18n="hideFrame"></span></a>
+            <?php endif; ?>
+            <a href="<?php echo PathUtility::getPublicPath('test'); ?>" class="<?php echo $btnClass; ?> backBtn"><span data-i18n="back"></span></a>
         </div>
     </div>
 
-    <?php include($fileRoot . 'template/components/main.footer.php'); ?>
+    <?php include PathUtility::getAbsolutePath('template/components/main.footer.php'); ?>
 
-    <script type="text/javascript" src="<?=$fileRoot?>resources/js/preview.js?v=<?php echo $config['photobooth']['version']; ?>"></script>
-    <script type="text/javascript" src="<?=$fileRoot?>resources/js/test_preview.js?v=<?php echo $config['photobooth']['version']; ?>"></script>
+    <script type="text/javascript" src="<?=PathUtility::getPublicPath()?>resources/js/preview.js?v=<?php echo $config['photobooth']['version']; ?>"></script>
+    <script type="text/javascript" src="<?=PathUtility::getPublicPath()?>resources/js/test_preview.js?v=<?php echo $config['photobooth']['version']; ?>"></script>
 
 </body>
 </html>

--- a/test/trigger.php
+++ b/test/trigger.php
@@ -1,7 +1,8 @@
 <?php
 
-$fileRoot = '../';
-require_once $fileRoot . 'lib/boot.php';
+require_once '../lib/boot.php';
+
+use Photobooth\Utility\PathUtility;
 
 $pageTitle = $config['ui']['branding'] . ' Remote Trigger';
 $mainStyle = 'trigger.css';
@@ -9,54 +10,53 @@ $photoswipe = false;
 $remoteBuzzer = false;
 $chromaKeying = false;
 
-include($fileRoot . 'template/components/main.head.php');
+include PathUtility::getAbsolutePath('template/components/main.head.php');
 ?>
-
 <body>
 
     <div id="wrapper">
-		<div class="buttonbar">
+        <div class="buttonbar">
 
-			<?php if ($config['remotebuzzer']['usebuttons']): ?>
-			<?php if ($config['picture']['enabled'] && $config['remotebuzzer']['picturebutton']): ?>
-			    <a href="#" class="<?php echo $btnClass; ?> remotePicture" onclick="photoboothTools.getRequest('http://' + config.remotebuzzer.serverip + ':' + config.remotebuzzer.port + '/commands/start-picture');"><i class="<?php echo $config['icons']['take_picture'] ?>"></i> <span data-i18n="takePhoto"></span></a>
-			    <?php endif; ?>
+            <?php if ($config['remotebuzzer']['usebuttons']): ?>
+            <?php if ($config['picture']['enabled'] && $config['remotebuzzer']['picturebutton']): ?>
+                <a href="#" class="<?php echo $btnClass; ?> remotePicture" onclick="photoboothTools.getRequest('http://' + config.remotebuzzer.serverip + ':' + config.remotebuzzer.port + '/commands/start-picture');"><i class="<?php echo $config['icons']['take_picture'] ?>"></i> <span data-i18n="takePhoto"></span></a>
+                <?php endif; ?>
 
-			    <?php if ($config['collage']['enabled'] && $config['remotebuzzer']['collagebutton']): ?>
-			    <a href="#" class="<?php echo $btnClass; ?> remoteCollage" onclick="photoboothTools.getRequest('http://' + config.remotebuzzer.serverip + ':' + config.remotebuzzer.port + '/commands/start-collage');"><i class="<?php echo $config['icons']['take_collage'] ?>"></i> <span data-i18n="takeCollage"></span></a>
-			    <?php endif; ?>
+                <?php if ($config['collage']['enabled'] && $config['remotebuzzer']['collagebutton']): ?>
+                <a href="#" class="<?php echo $btnClass; ?> remoteCollage" onclick="photoboothTools.getRequest('http://' + config.remotebuzzer.serverip + ':' + config.remotebuzzer.port + '/commands/start-collage');"><i class="<?php echo $config['icons']['take_collage'] ?>"></i> <span data-i18n="takeCollage"></span></a>
+                <?php endif; ?>
 
-			    <?php if ($config['custom']['enabled'] && $config['remotebuzzer']['custombutton']): ?>
-			    <a href="#" class="<?php echo $btnClass; ?> remoteCustom" onclick="photoboothTools.getRequest('http://' + config.remotebuzzer.serverip + ':' + config.remotebuzzer.port + '/commands/start-custom');"><i class="<?php echo $config['icons']['take_custom'] ?>"></i> <span><?php echo $config['custom']['btn_text'] ?></span></a>
-			    <?php endif; ?>
+                <?php if ($config['custom']['enabled'] && $config['remotebuzzer']['custombutton']): ?>
+                <a href="#" class="<?php echo $btnClass; ?> remoteCustom" onclick="photoboothTools.getRequest('http://' + config.remotebuzzer.serverip + ':' + config.remotebuzzer.port + '/commands/start-custom');"><i class="<?php echo $config['icons']['take_custom'] ?>"></i> <span><?php echo $config['custom']['btn_text'] ?></span></a>
+                <?php endif; ?>
 
-			    <?php if ($config['video']['enabled'] && $config['remotebuzzer']['videobutton']): ?>
-			    <a href="#" class="<?php echo $btnClass; ?> remoteVideo" onclick="photoboothTools.getRequest('http://' + config.remotebuzzer.serverip + ':' + config.remotebuzzer.port + '/commands/start-video');"><i class="<?php echo $config['icons']['take_video'] ?>"></i> <span data-i18n="takeVideo"></span></a>
-			    <?php endif; ?>
+                <?php if ($config['video']['enabled'] && $config['remotebuzzer']['videobutton']): ?>
+                <a href="#" class="<?php echo $btnClass; ?> remoteVideo" onclick="photoboothTools.getRequest('http://' + config.remotebuzzer.serverip + ':' + config.remotebuzzer.port + '/commands/start-video');"><i class="<?php echo $config['icons']['take_video'] ?>"></i> <span data-i18n="takeVideo"></span></a>
+                <?php endif; ?>
 
-			    <?php if ($config['print']['from_result'] && $config['remotebuzzer']['printbutton']): ?>
-			    <a href="#" class="<?php echo $btnClass; ?> remotePrint" onclick="photoboothTools.getRequest('http://' + config.remotebuzzer.serverip + ':' + config.remotebuzzer.port + '/commands/start-print');"><i class="<?php echo $config['icons']['print'] ?>"></i> <span data-i18n="print"></span></a>
-			    <?php endif; ?>
+                <?php if ($config['print']['from_result'] && $config['remotebuzzer']['printbutton']): ?>
+                <a href="#" class="<?php echo $btnClass; ?> remotePrint" onclick="photoboothTools.getRequest('http://' + config.remotebuzzer.serverip + ':' + config.remotebuzzer.port + '/commands/start-print');"><i class="<?php echo $config['icons']['print'] ?>"></i> <span data-i18n="print"></span></a>
+                <?php endif; ?>
 
-			    <?php if ($config['remotebuzzer']['rebootbutton']): ?>
-			    <a href="#" class="<?php echo $btnClass; ?> remoteReboot" onclick="photoboothTools.getRequest('http://' + config.remotebuzzer.serverip + ':' + config.remotebuzzer.port + '/commands/reboot-now');"><i class="fa fa-exclamation-triangle" aria-hidden="true"></i> <span data-i18n="reboot_button"></span></a>
-			    <?php endif; ?>
+                <?php if ($config['remotebuzzer']['rebootbutton']): ?>
+                <a href="#" class="<?php echo $btnClass; ?> remoteReboot" onclick="photoboothTools.getRequest('http://' + config.remotebuzzer.serverip + ':' + config.remotebuzzer.port + '/commands/reboot-now');"><i class="fa fa-exclamation-triangle" aria-hidden="true"></i> <span data-i18n="reboot_button"></span></a>
+                <?php endif; ?>
 
-			    <?php if ($config['remotebuzzer']['shutdownbutton']): ?>
-			    <a href="#" class="<?php echo $btnClass; ?> remoteShutdown" onclick="photoboothTools.getRequest('http://' + config.remotebuzzer.serverip + ':' + config.remotebuzzer.port + '/commands/shutdown-now');"><i class="fa fa-exclamation-triangle" aria-hidden="true"></i> <span data-i18n="shutdown_button"></span></a>
-			    <?php endif; ?>
+                <?php if ($config['remotebuzzer']['shutdownbutton']): ?>
+                <a href="#" class="<?php echo $btnClass; ?> remoteShutdown" onclick="photoboothTools.getRequest('http://' + config.remotebuzzer.serverip + ':' + config.remotebuzzer.port + '/commands/shutdown-now');"><i class="fa fa-exclamation-triangle" aria-hidden="true"></i> <span data-i18n="shutdown_button"></span></a>
+                <?php endif; ?>
 
-			<?php endif; ?>
+            <?php endif; ?>
 
-			<?php if ($config['remotebuzzer']['userotary']): ?>
-			    <a href="#" class="<?php echo $btnClass; ?> remotePrevious" onclick="photoboothTools.getRequest('http://' + config.remotebuzzer.serverip + ':' + config.remotebuzzer.port + '/commands/rotary-ccw');"><i class="fa fa-chevron-left" aria-hidden="true"></i> <span data-i18n="previous_element"></span></a>
-			    <a href="#" class="<?php echo $btnClass; ?> remoteNext" onclick="photoboothTools.getRequest('http://' + config.remotebuzzer.serverip + ':' + config.remotebuzzer.port + '/commands/rotary-cw');"><i class="fa fa-chevron-right" aria-hidden="true"></i> <span data-i18n="next_element"></span></a>
-			    <a href="#" class="<?php echo $btnClass; ?> remoteClick" onclick="photoboothTools.getRequest('http://' + config.remotebuzzer.serverip + ':' + config.remotebuzzer.port + '/commands/rotary-btn-press');"><i class="fa fa-circle" aria-hidden="true"></i> <span data-i18n="click_element"></span></a>
-			<?php endif; ?>
-			    <a href="<?php echo $fileRoot . 'test'; ?>" class="<?php echo $btnClass; ?>"><i class="fa fa-chevron-left" aria-hidden="true"></i> <span data-i18n="back"></span></a>
-		</div>
-	</div>
+            <?php if ($config['remotebuzzer']['userotary']): ?>
+                <a href="#" class="<?php echo $btnClass; ?> remotePrevious" onclick="photoboothTools.getRequest('http://' + config.remotebuzzer.serverip + ':' + config.remotebuzzer.port + '/commands/rotary-ccw');"><i class="fa fa-chevron-left" aria-hidden="true"></i> <span data-i18n="previous_element"></span></a>
+                <a href="#" class="<?php echo $btnClass; ?> remoteNext" onclick="photoboothTools.getRequest('http://' + config.remotebuzzer.serverip + ':' + config.remotebuzzer.port + '/commands/rotary-cw');"><i class="fa fa-chevron-right" aria-hidden="true"></i> <span data-i18n="next_element"></span></a>
+                <a href="#" class="<?php echo $btnClass; ?> remoteClick" onclick="photoboothTools.getRequest('http://' + config.remotebuzzer.serverip + ':' + config.remotebuzzer.port + '/commands/rotary-btn-press');"><i class="fa fa-circle" aria-hidden="true"></i> <span data-i18n="click_element"></span></a>
+            <?php endif; ?>
+                <a href="<?php echo PathUtility::getPublicPath('test'); ?>" class="<?php echo $btnClass; ?>"><i class="fa fa-chevron-left" aria-hidden="true"></i> <span data-i18n="back"></span></a>
+        </div>
+    </div>
 
-    <?php include($fileRoot . 'template/components/main.footer.php'); ?>
+    <?php include PathUtility::getAbsolutePath('template/components/main.footer.php'); ?>
 </body>
 </html>

--- a/welcome/index.php
+++ b/welcome/index.php
@@ -1,24 +1,21 @@
 <?php
 
-$fileRoot = '../';
-require_once $fileRoot . 'lib/boot.php';
+require_once '../lib/boot.php';
 
 use Photobooth\Photobooth;
 use Photobooth\HealthCheck;
+use Photobooth\Utility\PathUtility;
 
 $photobooth = new Photobooth();
-$URL = $photobooth->getUrl();
 
-$PHOTOBOOTH_HOME = realpath($fileRoot);
-$PHOTOBOOTH_HOME = rtrim($PHOTOBOOTH_HOME, DIRECTORY_SEPARATOR);
 $pageTitle = 'Welcome to ' . $config['ui']['branding'];
 $remoteBuzzer = false;
 $photoswipe = false;
 $chromaKeying = false;
 
-include($fileRoot . 'admin/components/head.admin.php');
-include($fileRoot . 'admin/helper/index.php');
-include($fileRoot . 'admin/inputs/index.php');
+include PathUtility::getAbsolutePath('admin/components/head.admin.php');
+include PathUtility::getAbsolutePath('admin/helper/index.php');
+include PathUtility::getAbsolutePath('admin/inputs/index.php');
 
 $healthCheck = new HealthCheck();
 $healthData = '<h3 class="font-bold uppercase underline pb-2"><span data-i18n="healthStatus"></span></h3>';
@@ -38,103 +35,103 @@ $healthData .= $healthCheck->healthStatus ? '<p><b><span data-i18n="healthGood">
 ?>
 
 <div class="w-full h-full grid place-items-center fixed bg-brand-2 overflow-x-hidden overflow-y-auto">
-		<div class="w-full flex items-center justify-center flex-col px-6 py-12"> 
+        <div class="w-full flex items-center justify-center flex-col px-6 py-12">
 
-			<div class="w-full max-w-4xl h-144 rounded-lg bg-white flex flex-col shadow-xl">
+            <div class="w-full max-w-4xl h-144 rounded-lg bg-white flex flex-col shadow-xl">
 
-				<div class="p-4 md:p-8">
-					<div class="w-full flex items-center pb-3 mb-4 border-b border-solid border-gray-200 justify-center">
-						<h2 class="text-brand-1 text-xl text-center font-bold">
-							Welcome to your own Photobooth
-						</h2>
-					</div>
+                <div class="p-4 md:p-8">
+                    <div class="w-full flex items-center pb-3 mb-4 border-b border-solid border-gray-200 justify-center">
+                        <h2 class="text-brand-1 text-xl text-center font-bold">
+                            Welcome to your own Photobooth
+                        </h2>
+                    </div>
 
-					<div>
-						<p>OpenSource Photobooth web interface for Linux and Windows.</p>
-						<p></p>
-						<p>Photobooth was initally developped by Andre Rinas especially to run on a Raspberry Pi.<br>
-						In 2019 Andreas Blaesius picked up the work and continued to work on the source.</p>
-						<p class="mt-2">
-							With the help of the community Photobooth grew to a powerfull Photobooth software with a lot of features and possibilities.
-							By a lot of features, we mean a lot (!!!) and you might have some questions - now or later. You can find a lot of useful information
-							<a class="underline hover:text-brand-1" href="https://photoboothproject.github.io" target="_blank" rel="noopener noreferrer">https://photoboothproject.github.io</a> 
-							or at the 
-							<a class="underline hover:text-brand-1" href="https://t.me/PhotoboothGroup" target="_blank" rel="noopener noreferrer">Telegram group</a>.
-						</p>
-						</p>
-						<h3 class="text-brand-1 font-bold mb-2 mt-4">Here are some basic information for you:</h3>
-						<p class="mb-2">
-							<b class="flex mb-1">Location of your Photobooth installation:</b>
-							<code class="break-all"><?=$PHOTOBOOTH_HOME?></code><br>
-							<i class="text-xs text-gray-500">All files and folders inside this path belong to the Webserver user "www-data".</i>
-						</p>
-						<p class="mb-3">
-							<b class="flex mb-1">Images can be found at:</b> 
-							<code class="break-all"><?=$config['foldersAbs']['images']?></code>
-						</p>
-						<p class="mb-3">
-							<b class="flex mb-1">Databases are placed at:</b> 
-							<code class="break-all"><?=$config['foldersAbs']['data']?></code>
-						</p>
-						<p>
-							<b class="flex mb-1">Add your own files (e.g. background images, frames, overrides.css) inside:</b>
-							<code class="break-all"><?=$PHOTOBOOTH_HOME . DIRECTORY_SEPARATOR . 'private'?></code><br>
-							<i class="text-xs text-gray-500">All files and folders inside this path will be ignored on git and won't cause trouble while updating Photobooth.</i>
-						</p>
-						<p class="mt-4">
-							You can change the settings and look of Photobooth using the Admin panel at 
-							<code class="break-all"><a class="hover:text-brand-1" href="../admin" target="_blank" rel="noopener noreferrer"><?=$URL;?>/admin</a></code>.
-						</p>
-						<p class="mt-1">
-							A standalone gallery can be found at 
-							<code class="break-all"><a class="hover:text-brand-1" href="../gallery" target="_blank" rel="noopener noreferrer"><?=$URL;?>/gallery</a></code>.
-						</p>
-						<p class="mt-1">
-							A standalone slideshow can be found at 
-							<code class="break-all"><a class="hover:text-brand-1" href="../slideshow" target="_blank" rel="noopener noreferrer"><?=$URL;?>/slideshow</a></code>.
-						</p>
-						<p class="mt-1">
-							An integrated FAQ to answer a lot of questions can be found at 
-							<code class="break-all"><a class="hover:text-brand-1" href="../faq" target="_blank" rel="noopener noreferrer"><?=$URL;?>/faq</a></code>.
-						</p>
-						<p class="mt-4">
-							You are missing some translation or your language isn't supported yet? 
-							Don't worry! You can request new language support at <a class="underline hover:text-brand-1" href="https://github.com/PhotoboothProject/photobooth/issues" target="_blank" rel="noopener noreferrer">GitHub</a>,
-							you can translate Photobooth at <a class="underline hover:text-brand-1" href="https://crowdin.com/project/photobooth" target="_blank" rel="noopener noreferrer">Crowdin</a>.
-						</p>
-					</div>
+                    <div>
+                        <p>OpenSource Photobooth web interface for Linux and Windows.</p>
+                        <p></p>
+                        <p>Photobooth was initally developped by Andre Rinas especially to run on a Raspberry Pi.<br>
+                        In 2019 Andreas Blaesius picked up the work and continued to work on the source.</p>
+                        <p class="mt-2">
+                            With the help of the community Photobooth grew to a powerfull Photobooth software with a lot of features and possibilities.
+                            By a lot of features, we mean a lot (!!!) and you might have some questions - now or later. You can find a lot of useful information
+                            <a class="underline hover:text-brand-1" href="https://photoboothproject.github.io" target="_blank" rel="noopener noreferrer">https://photoboothproject.github.io</a>
+                            or at the
+                            <a class="underline hover:text-brand-1" href="https://t.me/PhotoboothGroup" target="_blank" rel="noopener noreferrer">Telegram group</a>.
+                        </p>
+                        </p>
+                        <h3 class="text-brand-1 font-bold mb-2 mt-4">Here are some basic information for you:</h3>
+                        <p class="mb-2">
+                            <b class="flex mb-1">Location of your Photobooth installation:</b>
+                            <code class="break-all"><?=PathUtility::getRootPath()?></code><br>
+                            <i class="text-xs text-gray-500">All files and folders inside this path belong to the Webserver user "www-data".</i>
+                        </p>
+                        <p class="mb-3">
+                            <b class="flex mb-1">Images can be found at:</b>
+                            <code class="break-all"><?=$config['foldersAbs']['images']?></code>
+                        </p>
+                        <p class="mb-3">
+                            <b class="flex mb-1">Databases are placed at:</b>
+                            <code class="break-all"><?=$config['foldersAbs']['data']?></code>
+                        </p>
+                        <p>
+                            <b class="flex mb-1">Add your own files (e.g. background images, frames, overrides.css) inside:</b>
+                            <code class="break-all"><?=PathUtility::getAbsolutePath('private')?></code><br>
+                            <i class="text-xs text-gray-500">All files and folders inside this path will be ignored on git and won't cause trouble while updating Photobooth.</i>
+                        </p>
+                        <p class="mt-4">
+                            You can change the settings and look of Photobooth using the Admin panel at
+                            <code class="break-all"><a class="hover:text-brand-1" href="<?=PathUtility::getPublicPath('admin');?>" target="_blank" rel="noopener noreferrer"><?=PathUtility::getPublicPath('admin');?></a></code>.
+                        </p>
+                        <p class="mt-1">
+                            A standalone gallery can be found at
+                            <code class="break-all"><a class="hover:text-brand-1" href="<?=PathUtility::getPublicPath('gallery');?>" target="_blank" rel="noopener noreferrer"><?=PathUtility::getPublicPath('gallery');?></a></code>.
+                        </p>
+                        <p class="mt-1">
+                            A standalone slideshow can be found at
+                            <code class="break-all"><a class="hover:text-brand-1" href="<?=PathUtility::getPublicPath('slideshow');?>" target="_blank" rel="noopener noreferrer"><?=PathUtility::getPublicPath('slideshow');?></a></code>.
+                        </p>
+                        <p class="mt-1">
+                            An integrated FAQ to answer a lot of questions can be found at
+                            <code class="break-all"><a class="hover:text-brand-1" href="<?=PathUtility::getPublicPath('faq');?>" target="_blank" rel="noopener noreferrer"><?=PathUtility::getPublicPath('faq');?></a></code>.
+                        </p>
+                        <p class="mt-4">
+                            You are missing some translation or your language isn't supported yet?
+                            Don't worry! You can request new language support at <a class="underline hover:text-brand-1" href="https://github.com/PhotoboothProject/photobooth/issues" target="_blank" rel="noopener noreferrer">GitHub</a>,
+                            you can translate Photobooth at <a class="underline hover:text-brand-1" href="https://crowdin.com/project/photobooth" target="_blank" rel="noopener noreferrer">Crowdin</a>.
+                        </p>
+                    </div>
 
-				</div>
+                </div>
 
-				<div class="p-4 md:px-8 md:py-4 bg-yellow-300 text-sm">
-					<b class="flex mb-2 text-red-500">Security advice</b>
-					Photobooth is not hardened against any kind of <i>targeted</i> attacks.<br>
-					It uses user defined commands for tasks like taking photos and is allowed to replace its own files for easy updating.<br>
-					Because of this it's not advised to operate Photobooth in an untrusted network and<br>
-					<b class="text-red-500">you should absolutely not make Photobooth accessible through the internet without heavy modifications!</b></p>
-					<p></p>
-				</div>
+                <div class="p-4 md:px-8 md:py-4 bg-yellow-300 text-sm">
+                    <b class="flex mb-2 text-red-500">Security advice</b>
+                    Photobooth is not hardened against any kind of <i>targeted</i> attacks.<br>
+                    It uses user defined commands for tasks like taking photos and is allowed to replace its own files for easy updating.<br>
+                    Because of this it's not advised to operate Photobooth in an untrusted network and<br>
+                    <b class="text-red-500">you should absolutely not make Photobooth accessible through the internet without heavy modifications!</b></p>
+                    <p></p>
+                </div>
 
 
-				<div class="p-4 md:p-8">
-					<p class="text-center">Thanks for the reading!</p>
-					<?php
+                <div class="p-4 md:p-8">
+                    <p class="text-center">Thanks for the reading!</p>
+                    <?php
                     $healthCheckBg = $healthCheck->healthStatus ? 'bg-green-500' : 'bg-red-500';
 if ($healthCheck->healthStatus) {
     echo '<div class="w-full max-w-md p-5 mx-auto mt-2">';
-    echo getMenuBtn($fileRoot, 'enjoyPhotobooth', '');
+    echo getMenuBtn(PathUtility::getPublicPath(''), 'enjoyPhotobooth', '');
     echo '</div>';
 }
 echo '<div class="w-full p-5 mx-auto mt-2 rounded-lg ' . $healthCheckBg . ' text-white text-center">';
 echo $healthData;
 ?>
-					</div>
-				</div>
+                    </div>
+                </div>
 
-			</div>
+            </div>
 
-		</div>
-	</div>
+        </div>
+    </div>
 
     <?php
     if ($healthCheck->healthStatus) {
@@ -143,7 +140,7 @@ echo $healthData;
         }
 
     }
-    include($fileRoot . 'template/components/main.footer.php');
+    include PathUtility::getAbsolutePath('template/components/main.footer.php');
 ?>
 
 </body>


### PR DESCRIPTION
task: streamline path handling

This patch aims to streamline the path handling.
The variable $fileRoot was passed through includes
multiple times and includes relying on it to be correct.

We are now removing this variable and all
manually set/assumed paths. With the
introduction of the PathUtility, all paths can be
correctly and reliably calculated. It auto-detects
subfolder installations and adjusts the paths
accordingly.