### PR TITLE
bugfix: harden language service

### DIFF
--- a/config/config.inc.php
+++ b/config/config.inc.php
@@ -9,7 +9,7 @@ $config = [];
 // G E N E R A L
 // possible language values: de, en, fr, it
 $config['ui']['language'] = 'en';
-$config['ui']['folders_lang'] = '';
+$config['ui']['folders_lang'] = 'resources/lang';
 $config['adminpanel']['view'] = 'basic';
 $config['adminpanel']['experimental_settings'] = false;
 $config['dev']['loglevel'] = '1';

--- a/lib/boot.php
+++ b/lib/boot.php
@@ -35,7 +35,10 @@ require_once dirname(__DIR__) . '/lib/config.php';
 // $languageService = LanguageService::getInstance();
 // $languageService->translate('abort');
 //
-$GLOBALS[LanguageService::class] = new LanguageService($config['ui']['language'] ?? 'en', $config['ui']['folders_lang']);
+$GLOBALS[LanguageService::class] = new LanguageService(
+    $config['ui']['language'] ?? 'en',
+    isset($config['ui']['folders_lang']) && $config['ui']['folders_lang'] !== '' ? $config['ui']['folders_lang'] : 'resources/lang'
+);
 
 define('DB_FILE', $config['foldersAbs']['data'] . DIRECTORY_SEPARATOR . $config['database']['file'] . '.txt');
 define('MAIL_FILE', $config['foldersAbs']['data'] . DIRECTORY_SEPARATOR . $config['mail']['file'] . '.txt');

--- a/lib/config.php
+++ b/lib/config.php
@@ -150,12 +150,6 @@ if (file_exists(PathUtility::getAbsolutePath('config/my.config.inc.php')) && !is
     die('Abort. Can not create config/my.config.inc.php. Config folder is not writable.');
 }
 
-if (empty($config['ui']['folders_lang'])) {
-    $config['ui']['folders_lang'] = 'resources/lang';
-}
-
-$config['ui']['folders_lang'] = PathUtility::getPublicPath($config['ui']['folders_lang']);
-
 foreach ($config['folders'] as $key => $folder) {
     if ($folder === 'data' || $folder === 'archives' || $folder === 'config' || $folder === 'private') {
         $path = PathUtility::getAbsolutePath($folder);

--- a/lib/src/Utility/PathUtility.php
+++ b/lib/src/Utility/PathUtility.php
@@ -24,7 +24,7 @@ class PathUtility
 
     public static function isAbsolutePath(string $path): bool
     {
-        return realpath($path) !== false;
+        return trim($path) !== '' && realpath($path) !== false;
     }
 
     public static function isUrl(string $path): bool


### PR DESCRIPTION
- set default to resources/lang
- do not use a public path for the lang folder
- pass default to service construct when the config is empty
- handle empty path in absolute path check
