### PR TITLE
admin shortcut: remove cursor css property

### DIFF
--- a/src/sass/components/_adminshortcut.scss
+++ b/src/sass/components/_adminshortcut.scss
@@ -10,7 +10,6 @@
   padding: 0;
   margin: 0;
   background-color: transparent;
-  cursor: pointer;
 
   &--top-left {
     top: 0rem;


### PR DESCRIPTION
It's a hidden, secret shortcut. User/guests should not easily find the shortcut.