### PR TITLE
remotebuzzer-server: allow GPIO to be any number

### DIFF
--- a/assets/js/remotebuzzer-server.js
+++ b/assets/js/remotebuzzer-server.js
@@ -505,10 +505,6 @@ function gpioPuSanity(gpioconfig) {
             throw new Error(gpioconfig + ' is not a valid number');
         }
 
-        if (gpioconfig < 1 || gpioconfig > 27) {
-            throw new Error('GPIO' + gpioconfig + ' number is out of range (1-27)');
-        }
-
         cmd = 'sed -n "s/^gpio=\\(.*\\)=pu/\\1/p" /boot/config.txt';
         stdout = execSync(cmd).toString();
 
@@ -530,10 +526,6 @@ function gpioOpSanity(gpioconfig) {
     try {
         if (isNaN(gpioconfig)) {
             throw new Error(gpioconfig + ' is not a valid number');
-        }
-
-        if (gpioconfig < 1 || gpioconfig > 27) {
-            throw new Error('GPIO' + gpioconfig + ' number is out of range (1-27)');
         }
 
         cmd = 'sed -n "s/^gpio=\\(.*\\)=op/\\1/p" /boot/config.txt';


### PR DESCRIPTION

Prepare for Pi5 GPIO support.
https://github.com/PhotoboothProject/photobooth/issues/528

On Raspberry Pi 5 high-value GPIO are used on sysfs.