### PR TITLE
install-photobooth: respect defined php version

### DIFF
--- a/install-photobooth.sh
+++ b/install-photobooth.sh
@@ -512,7 +512,7 @@ function common_software() {
 
 function apache_webserver() {
     info "### Installing Apache Webserver..."
-    apt-get -qq install -y apache2 libapache2-mod-php${PHP_VERSION}
+    apt-get -qq install -y apache2 libapache2-mod-php"${PHP_VERSION}"
     sudo systemctl enable --now apache2
 }
 

--- a/install-photobooth.sh
+++ b/install-photobooth.sh
@@ -512,7 +512,7 @@ function common_software() {
 
 function apache_webserver() {
     info "### Installing Apache Webserver..."
-    apt-get -qq install -y apache2 libapache2-mod-php
+    apt-get -qq install -y apache2 libapache2-mod-php${PHP_VERSION}
     sudo systemctl enable --now apache2
 }
 

--- a/install-photobooth.sh
+++ b/install-photobooth.sh
@@ -505,9 +505,6 @@ function common_software() {
         check_npm
     fi
 
-    # Install php composer
-    curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
-
 }
 
 function apache_webserver() {

--- a/install-photobooth.sh
+++ b/install-photobooth.sh
@@ -60,10 +60,10 @@ COMMON_PACKAGES=(
     'gphoto2'
     'libimage-exiftool-perl'
     'nodejs'
-    'php-gd'
-    'php-xml'
-    'php-zip'
-    'php-mbstring'
+    "php${PHP_VERSION}-gd"
+    "php${PHP_VERSION}-xml"
+    "php${PHP_VERSION}-zip"
+    "php${PHP_VERSION}-mbstring"
     'python3'
     'rsync'
     'udisks2'
@@ -504,6 +504,10 @@ function common_software() {
     if [ "$NEEDS_NPM_CHECK" = true ]; then
         check_npm
     fi
+
+    # Install php composer
+    curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+
 }
 
 function apache_webserver() {

--- a/install-photobooth.sh
+++ b/install-photobooth.sh
@@ -504,7 +504,6 @@ function common_software() {
     if [ "$NEEDS_NPM_CHECK" = true ]; then
         check_npm
     fi
-
 }
 
 function apache_webserver() {


### PR DESCRIPTION
#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/PhotoboothProject/photobooth/blob/dev/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "x" next to an item)
- [x] Bug fix
- [ ] Documentation update
- [ ] Bug fix
- [ ] New feature
- [ ] Other, please explain:

#### What changes did you make? (Give an overview)
- install-photobooth.sh: ~~Add composer and~~ modules depending on php version

#### Is there anything you'd like reviewers to focus on?
I installed photobooth on Rapberry Pi OS bookworm with the following command from the installation guide:

`
sudo bash install-photobooth.sh -username='<YourUsername>' -webserver='nginx'
`

It seems php modules gd, xml, zip and mbstring are not installed/activated correctly.
~~Also composer was missing, so the installation failed, so I like to fix it in this PR.~~