### PR TITLE
Add option to install mjpeg support only (and not run a full photobooth installation)

### DIFF
--- a/docs/install/install-debian.md
+++ b/docs/install/install-debian.md
@@ -35,8 +35,9 @@ sudo bash install-photobooth.sh -username='<YourUsername>' -webserver='lighttpd'
 ```
 
 If you want to use your camera as a live preview for your photobooth users, you could
-add the `--mjpeg` option which installs `go2rtc`. Then you just have to set the
-preview mode to `URL` (be sure to enable expert mode) and set this as preview url:
+add the `--mjpeg` option which installs `go2rtc` (or use `--mjpeg-only` to only
+install go2rtc, then exit). Then you just have to set the preview mode to `URL` (be sure to
+enable expert mode) and set this as preview url:
 
 > [url(http://localhost:1984/stream.html?src=dslr&mode=mjpeg)](http://localhost:1984/stream.html?src=dslr&mode=mjpeg)
 

--- a/docs/install/install-windows.md
+++ b/docs/install/install-windows.md
@@ -98,7 +98,7 @@ sudo bash install-photobooth.sh --username='<YourUsername>' --mjpeg --silent
 Now open the [admin section](http://localhost/admin) and
 set this as the live preview url:
 
-> [url(http://localhost:1984/stream.html?src=dslr&mode=mjpeg)](http://localhost:1984/stream.html?src=dslr&mode=mjpeg)
+> [url(http://localhost:1984/api/stream.mjpeg?src=dslr)](http://localhost:1984/api/stream.mjpeg?src=dslr)
 
 and this as capture command: `capture %s`.
 

--- a/install-photobooth.sh
+++ b/install-photobooth.sh
@@ -22,6 +22,7 @@ USB_SYNC=false
 SETUP_CUPS=false
 GPHOTO_PREVIEW=true
 MJPEG_PREVIEW=false
+MJPEG_PREVIEW_ONLY=false
 CUPS_REMOTE_ANY=false
 WEBBROWSER="unknown"
 KIOSK_FLAG="--kiosk http://localhost"
@@ -185,6 +186,8 @@ Usage: sudo bash install-photobooth.sh -u=<YourUsername> [-b=<stable4:dev:packag
 
     -m,  -mjpeg,      --mjpeg       Install go2rtc to provide remote preview (via URL) of your camera.
 
+    -M,  -mjpeg-only, --mjpeg-only  Only install go2rtc to provide remote preview (via URL) of your camera, then exit
+
     -V,  -verbose,    --verbose     Run script in verbose mode.
 
     -w,  -webserver,  --webserver   Enter the webserver to use [apache, nginx, lighttpd].
@@ -204,7 +207,7 @@ info "### The Photobooth installer for your Raspberry Pi."
 print_spaces
 info "################## Passed options #########################"
 echo ""
-options=$(getopt -l "help,branch::,php::,update,username::,raspberry,mjpeg,silent,verbose,webserver::" -o "hb::p::u::rsmVw::" -a -- "$@")
+options=$(getopt -l "help,branch::,php::,update,username::,raspberry,mjpeg,mjpeg-only,silent,verbose,webserver::" -o "hb::p::u::rsmMVw::" -a -- "$@")
 eval set -- "$options"
 
 while true; do
@@ -250,6 +253,10 @@ while true; do
         MJPEG_PREVIEW=true
         GPHOTO_PREVIEW=false
         info "### Mjpeg mode enabled"
+        ;;
+    -M | --mjpeg-only)
+        MJPEG_PREVIEW_ONLY=true
+        info "### Only install mjpeg"
         ;;
     -s | --silent)
         SILENT_INSTALL=true
@@ -1179,6 +1186,11 @@ detect_photobooth_install() {
 if [ "$UID" != 0 ]; then
     error "ERROR: Only root is allowed to execute the installer. Forgot sudo?"
     exit 1
+fi
+
+if [ "$MJPEG_PREVIEW_ONLY" = true ]; then
+    mjpeg_preview
+    exit 0
 fi
 
 if [ "$USERNAME" != "" ]; then

--- a/install-photobooth.sh
+++ b/install-photobooth.sh
@@ -769,8 +769,7 @@ function ask_kiosk_mode() {
     echo -e "\033[0;33m### You probably like to start $WEBBROWSER on every start."
     ask_yes_no "### Open $WEBBROWSER in Kiosk Mode at every boot? [y/N] " "Y"
     echo -e "\033[0m"
-    if [[ $REPLY =~ ^[Yy]$ ]]
-    then
+    if [[ $REPLY =~ ^[Yy]$ ]]; then
         KIOSK_MODE=true
         info "### We will open $WEBBROWSER in Kiosk Mode at every boot."
     else
@@ -928,7 +927,7 @@ function hide_mouse() {
             sed -i '/Photobooth/,/Photobooth End/d' /etc/xdg/lxsession/LXDE-pi/autostart
         fi
 
-        cat >> /etc/xdg/lxsession/LXDE-pi/autostart <<EOF
+        cat >>/etc/xdg/lxsession/LXDE-pi/autostart <<EOF
 # Photobooth
 # turn off display power management system
 @xset -dpms
@@ -1253,14 +1252,14 @@ if [ "$RUN_UPDATE" = true ]; then
         fi
         print_spaces
 
-# Pi specific setup start
+        # Pi specific setup start
         if [ "$RUNNING_ON_PI" = true ] && [ "$DESKTOP_OS" = true ]; then
             ask_hide_mouse
         else
             info "### lxde is not installed. Can not hide the mouse cursor on every start."
         fi
         print_spaces
-# Pi specific setup end
+        # Pi specific setup end
 
         if [ -d "/etc/polkit-1/localauthority/50-local.d" ]; then
             ask_usb_sync
@@ -1297,7 +1296,7 @@ if [ "$RUN_UPDATE" = true ]; then
             info "### Browser unknown or not installed. Can not add shortcut to Desktop."
         fi
 
-        if [ "$HIDE_MOUSE" = true ] ; then
+        if [ "$HIDE_MOUSE" = true ]; then
             hide_mouse
         fi
 
@@ -1486,7 +1485,7 @@ if [ "$WEBBROWSER" != "unknown" ]; then
 else
     info "### Browser unknown or not installed. Can not add shortcut to Desktop."
 fi
-if [ "$HIDE_MOUSE" = true ] ; then
+if [ "$HIDE_MOUSE" = true ]; then
     hide_mouse
 fi
 if [ "$SETUP_CUPS" = true ]; then


### PR DESCRIPTION
#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/PhotoboothProject/photobooth/blob/dev/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "x" next to an item)

- [ ] Documentation update
- [ ] Bug fix
- [x] New feature
- [ ] Other, please explain:

#### What changes did you make? (Give an overview)

Added `--mjpeg-only` option which only runs the mjpeg installation function, then exits.