### PR TITLE
Check if go2rtc is even installed

### DIFF
--- a/install-photobooth.sh
+++ b/install-photobooth.sh
@@ -1075,9 +1075,13 @@ elif [[ \$# -gt 1 ]]; then
     args="\$@"
 fi
 
-sudo systemctl stop go2rtc.service
+if systemctl cat go2rtc.service >/dev/null; then
+    HAS_GO2RTC=1
+fi
+
+[[ -n "\$HAS_GO2RTC" ]] && sudo systemctl stop go2rtc.service
 gphoto2 \$args
-sudo systemctl start go2rtc.service
+[[ -n "\$HAS_GO2RTC" ]] && sudo systemctl start go2rtc.service
 EOF
         chmod +x /usr/local/bin/capture
     fi

--- a/install-photobooth.sh
+++ b/install-photobooth.sh
@@ -508,7 +508,7 @@ function common_software() {
 
 function apache_webserver() {
     info "### Installing Apache Webserver..."
-    apt-get -qq install -y apache2 libapache2-mod-php"${PHP_VERSION}"
+    apt-get -qq install -y apache2 libapache2-mod-php"$PHP_VERSION"
     sudo systemctl enable --now apache2
 }
 


### PR DESCRIPTION
#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/PhotoboothProject/photobooth/blob/dev/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "x" next to an item)

- [ ] Documentation update
- [ ] Bug fix
- [x] New feature
- [ ] Other, please explain:

#### What changes did you make? (Give an overview)

This check will ensure that the go2rtc service will only be used if it was installed before. If not, the capture script will act like a wrapper for gphoto2.