### PR TITLE
task: drop configuration path for config folder

### DIFF
--- a/config/config.inc.php
+++ b/config/config.inc.php
@@ -508,7 +508,6 @@ $config['reboot']['cmd'] = '';
 $config['shutdown']['cmd'] = '';
 
 // F O L D E R S
-$config['folders']['config'] = 'config';
 $config['folders']['data'] = 'data';
 $config['folders']['images'] = 'images';
 $config['folders']['keying'] = 'keying';

--- a/lib/config.php
+++ b/lib/config.php
@@ -93,7 +93,7 @@ if (file_exists(PathUtility::getAbsolutePath('config/my.config.inc.php')) && !is
 }
 
 foreach ($config['folders'] as $key => $folder) {
-    if ($folder === 'data' || $folder === 'config' || $folder === 'private') {
+    if ($folder === 'data' || $folder === 'private') {
         $path = PathUtility::getAbsolutePath($folder);
     } else {
         $path = PathUtility::getAbsolutePath($config['folders']['data'] . DIRECTORY_SEPARATOR . $folder);

--- a/lib/configsetup.inc.php
+++ b/lib/configsetup.inc.php
@@ -3278,13 +3278,6 @@ $configsetup = [
             'name' => 'folders[private]',
             'value' => $config['folders']['private'],
         ],
-        'folders_config' => [
-            'view' => 'expert',
-            'type' => 'hidden',
-            'placeholder' => $defaultConfig['folders']['config'],
-            'name' => 'folders[config]',
-            'value' => $config['folders']['config'],
-        ],
     ],
     'reset' => [
         'view' => 'basic',


### PR DESCRIPTION
Adjusting the path has no effect as the config is not respected and not necessary, the option is dropped to avoid confusion.