### PR TITLE
task: drop configuration path for private folder

### DIFF
--- a/admin/upload/index.php
+++ b/admin/upload/index.php
@@ -31,7 +31,7 @@ $btnClass = 'w-full h-12 rounded-full bg-brand-1 text-white flex items-center ju
 
 if (isset($_POST['submit'])) {
     $folderName = $_POST['folder_name'];
-    $folderPath = $config['foldersAbs']['private'] . DIRECTORY_SEPARATOR . 'images' . DIRECTORY_SEPARATOR . $folderName;
+    $folderPath = PathUtility::getAbsolutePath('private/images/' . $folderName);
     FileUtility::createDirectory($folderPath);
 
     if (is_writable($folderPath)) {

--- a/api/admin.php
+++ b/api/admin.php
@@ -223,7 +223,7 @@ if (isset($data['type'])) {
     }
 
     $collageLayout = $newConfig['collage']['layout'];
-    $collageConfigFilePath = __DIR__ . DIRECTORY_SEPARATOR . '..' . DIRECTORY_SEPARATOR . 'private/collage.json';
+    $collageConfigFilePath = PathUtility::getAbsolutePath('private/collage.json');
     if ($collageLayout === '1+2' || $collageLayout == '2+1' || $collageLayout == '2x3') {
         $newConfig['collage']['limit'] = 3;
     } elseif ($collageLayout == 'collage.json' && file_exists($collageConfigFilePath)) {

--- a/api/serverInfo.php
+++ b/api/serverInfo.php
@@ -26,7 +26,7 @@ function handleDebugPanel(string $content, array $config): string|false
         case 'nav-bootconfig':
             return readFileContents('/boot/config.txt');
         case 'nav-installlog':
-            return readFileContents($config['foldersAbs']['private'] . DIRECTORY_SEPARATOR . 'install.log');
+            return readFileContents(PathUtility::getAbsolutePath('private/install.log'));
         case 'nav-githead':
             return getLatestCommits();
         case 'nav-printdb':

--- a/config/config.inc.php
+++ b/config/config.inc.php
@@ -515,4 +515,3 @@ $config['folders']['print'] = 'print';
 $config['folders']['qrcodes'] = 'qrcodes';
 $config['folders']['thumbs'] = 'thumbs';
 $config['folders']['tmp'] = 'tmp';
-$config['folders']['private'] = 'private';

--- a/lib/config.php
+++ b/lib/config.php
@@ -93,7 +93,7 @@ if (file_exists(PathUtility::getAbsolutePath('config/my.config.inc.php')) && !is
 }
 
 foreach ($config['folders'] as $key => $folder) {
-    if ($folder === 'data' || $folder === 'private') {
+    if ($folder === 'data') {
         $path = PathUtility::getAbsolutePath($folder);
     } else {
         $path = PathUtility::getAbsolutePath($config['folders']['data'] . DIRECTORY_SEPARATOR . $folder);

--- a/lib/configsetup.inc.php
+++ b/lib/configsetup.inc.php
@@ -3271,13 +3271,6 @@ $configsetup = [
             'name' => 'folders[tmp]',
             'value' => $config['folders']['tmp'],
         ],
-        'folders_private' => [
-            'view' => 'expert',
-            'type' => 'hidden',
-            'placeholder' => $defaultConfig['folders']['private'],
-            'name' => 'folders[private]',
-            'value' => $config['folders']['private'],
-        ],
     ],
     'reset' => [
         'view' => 'basic',

--- a/src/Collage.php
+++ b/src/Collage.php
@@ -648,7 +648,7 @@ class Collage
                 }
                 break;
             default:
-                $collageConfigFilePath = PathUtility::getAbsolutePath('private' . DIRECTORY_SEPARATOR . $c->collageLayout);
+                $collageConfigFilePath = PathUtility::getAbsolutePath('private/' . $c->collageLayout);
                 $collageJson = json_decode((string)file_get_contents($collageConfigFilePath), true);
 
                 if (is_array($collageJson)) {


### PR DESCRIPTION
Adjusting the path is respected everywhere and not necessary, the option is dropped to avoid confusion.