### PR TITLE
task: allow cheesetimer to be set to 0

### DIFF
--- a/lib/configsetup.inc.php
+++ b/lib/configsetup.inc.php
@@ -448,7 +448,7 @@ return [
             'placeholder' => $defaultConfig['picture']['cheese_time'],
             'name' => 'picture[cheese_time]',
             'value' => $config['picture']['cheese_time'],
-            'range_min' => 250,
+            'range_min' => 0,
             'range_max' => 10000,
             'range_step' => 250,
             'unit' => 'milliseconds',

--- a/src/Configuration/PhotoboothConfiguration.php
+++ b/src/Configuration/PhotoboothConfiguration.php
@@ -1159,7 +1159,7 @@ class PhotoboothConfiguration implements ConfigurationInterface
                     ->end()
                 ->integerNode('cheese_time')
                     ->defaultValue(1000)
-                    ->min(250)
+                    ->min(0)
                     ->max(10000)
                     ->beforeNormalization()
                         ->ifString()


### PR DESCRIPTION
the cheese message stays until the picture is taken anyway, there is no need in general to configure it manually.