### PR TITLE
install-photobooth: remove preview options from main installer

### DIFF
--- a/docs/faq/index.md
+++ b/docs/faq/index.md
@@ -628,7 +628,7 @@ Make sure to have a stream available you can use (e.g. from your Webcam, Smartph
 
 If you want to use a stream from your DSLR or Pi Camera, install go2rtc and setup needed service to use.
 
-go2rtc can be accessed at `http://localhost:1984`. Use `url("http://localhost:1984/api/stream.mjpeg?src=dslr")` as _"Preview-URL"_ (replace `localhost` with Photobooths IP for remote access).
+go2rtc can be accessed at `http://localhost:1984`. Use `url("http://localhost:1984/api/stream.mjpeg?src=photobooth")` as _"Preview-URL"_ (replace `localhost` with Photobooths IP for remote access).
 To be able to also capture images you need to adjust the capture command.
 _"Commands"_: _"Take picture command"_: `capture %s`
 

--- a/docs/install/install-windows.md
+++ b/docs/install/install-windows.md
@@ -92,15 +92,11 @@ After creating the account, run these commands:
 
 ```bash
 wget https://raw.githubusercontent.com/PhotoboothProject/photobooth/dev/install-photobooth.sh
-sudo bash install-photobooth.sh --username='<YourUsername>' --mjpeg --silent
+sudo bash install-photobooth.sh --username='<YourUsername>' --silent
 ```
 
-Now open the [admin section](http://localhost/admin) and
-set this as the live preview url:
+Enjoy your Photobooth installation!
 
-> [url(http://localhost:1984/api/stream.mjpeg?src=dslr)](http://localhost:1984/api/stream.mjpeg?src=dslr)
-
-and this as capture command: `capture %s`.
 
 ## Direct installation on windows (method 2)
 

--- a/scripts/install-go2rtc-preview.sh
+++ b/scripts/install-go2rtc-preview.sh
@@ -32,6 +32,12 @@ function install_go2rtc() {
     local file
     local install_bin
 
+    if [[ -f /etc/systemd/system/go2rtc.service ]]; then
+        if systemctl is-active --quiet go2rtc.service; then
+            systemctl stop go2rtc.service
+        fi
+    fi
+
     if command -v go2rtc &>/dev/null; then
         if [[ $(go2rtc -version) =~ $GO2RTC_VERSION ]]; then
             info "### go2rtc version ${GO2RTC_VERSION} installed already!"
@@ -83,6 +89,10 @@ function install_go2rtc() {
         file="go2rtc_${os}_${goarch}"
         wget -O /usr/local/bin/go2rtc "https://github.com/AlexxIT/go2rtc/releases/download/${GO2RTC_VERSION}/${file}"
         chmod +x /usr/local/bin/go2rtc
+    fi
+
+    if [[ -f /etc/systemd/system/go2rtc.service ]]; then
+        systemctl start go2rtc.service
     fi
 }
 

--- a/scripts/install-go2rtc-preview.sh
+++ b/scripts/install-go2rtc-preview.sh
@@ -31,6 +31,7 @@ function install_go2rtc() {
     local os
     local file
     local install_bin
+    local installed_version
 
     if [[ -f /etc/systemd/system/go2rtc.service ]]; then
         if systemctl is-active --quiet go2rtc.service; then
@@ -39,7 +40,8 @@ function install_go2rtc() {
     fi
 
     if command -v go2rtc &>/dev/null; then
-        if [[ $(go2rtc -version) =~ $GO2RTC_VERSION ]]; then
+        installed_version=$(go2rtc -version 2>&1 | grep -oP 'version=\K[0-9]+\.[0-9]+\.[0-9]+' || go2rtc -version 2>&1 | grep -oP 'go2rtc version \K[0-9]+\.[0-9]+\.[0-9]+')
+        if [[ $installed_version == $GO2RTC_VERSION ]]; then
             info "### go2rtc version ${GO2RTC_VERSION} installed already!"
             install_bin=false
         else

--- a/scripts/install-go2rtc-preview.sh
+++ b/scripts/install-go2rtc-preview.sh
@@ -1,0 +1,195 @@
+#!/bin/bash
+
+GO2RTC_VERSION="v1.8.6-4"
+YAML_STREAM="dslr: exec:gphoto2 --capture-movie --stdout#killsignal=sigint"
+CAPTURE_CMD="gphoto2"
+CAPTURE_ARGS="--set-config output=Off --capture-image-and-download --filename=\$1"
+
+function info {
+    echo -e "\033[0;36m${1}\033[0m"
+}
+
+function error {
+    echo -e "\033[0;31m${1}\033[0m"
+}
+
+if [ "$UID" != 0 ]; then
+    error "ERROR: Only root is allowed to execute the installer. Forgot sudo?"
+    exit 1
+fi
+
+#Param 1: Question / Param 2: Default / silent answer
+function ask_yes_no {
+    read -p "${1}: " -n 1 -r
+}
+
+function mjpeg_preview() {
+    local arch
+    local goarch
+    local os
+    local file
+
+    if ! command -v go2rtc &>/dev/null || [[ ! $(go2rtc -version) =~ $GO2RTC_VERSION ]]; then
+        info "### Installing go2rtc (version: ${GO2RTC_VERSION})"
+
+        if [[ "$OSTYPE" =~ linux ]]; then
+            os=linux
+        elif [[ "$OSTYPE" =~ darwin ]]; then
+            os=darwin
+        elif [[ "$OSTYPE" =~ cygwin|mysys|win32 ]]; then
+            os=windows
+        else
+            error "### $OSTYPE not supported"
+            exit 1
+        fi
+
+        arch=$(uname -m)
+        if [[ "$arch" == "x86_64" ]]; then
+            goarch="amd64"
+        elif [[ "$arch" == "i386" ]]; then
+            goarch="386"
+        elif [[ "$arch" == "armv7l" ]]; then
+            goarch="armv7"
+        elif [[ "$arch" == "armv6l" ]]; then
+            goarch="armv6"
+        elif [[ "$arch" == "aarch64" ]]; then
+            goarch="arm64"
+        else
+            error "### $arch not supported"
+            exit 1
+        fi
+
+        if [[ ! -d /usr/local/bin ]]; then
+            mkdir -p /usr/local/bin
+        fi
+        file="go2rtc_${os}_${goarch}.tar.gz"
+        wget -P /tmp "https://github.com/dadav/go2rtc/releases/download/${GO2RTC_VERSION}/${file}"
+        tar xf "/tmp/${file}" -C /usr/local/bin go2rtc
+        rm /tmp/"$file"
+        chmod +x /usr/local/bin/go2rtc
+    fi
+
+    if [[ ! -f /etc/go2rtc.yaml ]]; then
+        info "### Creating /etc/go2rtc.yaml configuration file"
+        cat >/etc/go2rtc.yaml <<EOF
+---
+streams:
+  $YAML_STREAM
+EOF
+    fi
+
+    if [[ ! -f /etc/systemd/system/go2rtc.service ]]; then
+        info "### Creating go2rtc systemd service"
+        cat >/etc/systemd/system/go2rtc.service <<EOF
+[Unit]
+Description=go2rtc streaming software
+
+[Service]
+User=www-data
+ExecStart=/usr/local/bin/go2rtc -config /etc/go2rtc.yaml
+KillMode=process
+KillSignal=SIGINT
+
+[Install]
+WantedBy=multi-user.target
+EOF
+        systemctl daemon-reload
+        systemctl enable --now go2rtc.service
+    fi
+
+    if [[ ! -f /etc/sudoers.d/020_www-data-systemctl ]]; then
+        info "### Creating /etc/sudoers.d/020_www-data-systemctl"
+        cat >/etc/sudoers.d/020_www-data-systemctl <<EOF
+# Control streaming software
+www-data ALL=(ALL) NOPASSWD: /usr/bin/systemctl start go2rtc.service, /usr/bin/systemctl stop go2rtc.service
+EOF
+    fi
+
+    if [[ ! -f /usr/local/bin/capture ]]; then
+        info "### Creating /usr/local/bin/capture script"
+        cat >/usr/local/bin/capture <<EOF
+#!/bin/bash
+
+if [[ \$1 =~ -h|--help ]]; then
+  cat <<HELP
+This script stops go2rtc, runs $CAPTURE_CMD and starts go2rtc again.
+You can use it in your photobooth as capture command.
+
+Usage:
+
+    capture <filename> [or all required $CAPTURE_CMD arguments]
+
+In photobooth, usually 'capture %s' is enough. But if you want to use a more complex command,
+don't forget to add --filename=%s.
+
+HELP
+  exit 0
+fi
+
+if [[ \$# -eq 1 ]]; then
+    args="$CAPTURE_ARGS"
+elif [[ \$# -gt 1 ]]; then
+    args="\$@"
+fi
+
+if systemctl cat go2rtc.service >/dev/null; then
+    HAS_GO2RTC=1
+fi
+
+[[ -n "\$HAS_GO2RTC" ]] && sudo systemctl stop go2rtc.service
+$CAPTURE_CMD \$args
+[[ -n "\$HAS_GO2RTC" ]] && sudo systemctl start go2rtc.service
+EOF
+        chmod +x /usr/local/bin/capture
+    fi
+
+    info "### Done!"
+    info ""
+    info "    Please adjust your Photobooth configuration:"
+    info "    Preview mode: from URL"
+    info "    Preview-URL: url(\"http://localhost:1984/api/stream.mjpeg?src=dslr\")"
+    info "    Take picture command: capture %s"
+    warn "    Note: Countdown for pictures and collage should be set to a minimum of 6 seconds!"
+    info ""
+    info "### Have fun with your Photobooth, but first restart your device!"
+
+    echo -e "\033[0;33m"
+    ask_yes_no "### Do you like to reboot now? [y/N] " "N"
+    echo -e "\033[0m"
+    if [[ $REPLY =~ ^[Yy]$ ]]; then
+        info "### Your device will reboot now."
+        shutdown -r now
+    fi
+}
+
+info "Do you want to install a service to"
+info "be able to stream your camera to via?"
+info ""
+echo "Your options are:"
+echo "1 Install go2rtc and needed service for gphoto2"
+echo "2 Install go2rtc and needed service for rpicam-apps"
+echo "3 Install go2rtc and needed service for libcamera-apps"
+echo "4 Do nothing"
+info ""
+ask_yes_no "Please enter your choice:" "3"
+info ""
+if [[ $REPLY =~ ^[1]$ ]]; then
+    info "### We will install a service to set up a mjpeg stream for gphoto2."
+elif [[ $REPLY =~ ^[2]$ ]]; then
+    info "### We will install a service to set up a mjpeg stream for rpicam-apps."
+    YAML_STREAM="dslr: exec:rpicam-vid -t 0 --codec mjpeg -o -#killsignal=sigint"
+    CAPTURE_CMD="rpicam-still"
+    CAPTURE_ARGS="-n -q 100 -t 1 -o \$1"
+elif [[ $REPLY =~ ^[3]$ ]]; then
+    info "### We will install a service to set up a mjpeg stream for libcamera-apps."
+    YAML_STREAM="dslr: exec:libcamera-vid -t 0 --codec mjpeg -o -#killsignal=sigint"
+    CAPTURE_CMD="libcamera-still"
+    CAPTURE_ARGS="-n -q 100 -t 1 -o \$1"
+else
+    info "Okay... doing nothing!"
+    exit 0
+fi
+
+mjpeg_preview
+info "Done!"
+exit 0

--- a/scripts/install-go2rtc-preview.sh
+++ b/scripts/install-go2rtc-preview.sh
@@ -45,6 +45,7 @@ function install_go2rtc() {
             info "### go2rtc version ${GO2RTC_VERSION} installed already!"
             install_bin=false
         else
+            info "### Found go2rtc version: ${installed_version}"
             info "### Updating go2rtc to version: ${GO2RTC_VERSION}"
             install_bin=true
         fi

--- a/scripts/install-go2rtc-preview.sh
+++ b/scripts/install-go2rtc-preview.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-GO2RTC_VERSION="v1.8.6-4"
+GO2RTC_VERSION="v1.9.3"
 YAML_STREAM="dslr: exec:gphoto2 --capture-movie --stdout#killsignal=sigint"
 CAPTURE_CMD="gphoto2"
 CAPTURE_ARGS="--set-config output=Off --capture-image-and-download --filename=\$1"
@@ -36,9 +36,7 @@ function mjpeg_preview() {
         if [[ "$OSTYPE" =~ linux ]]; then
             os=linux
         elif [[ "$OSTYPE" =~ darwin ]]; then
-            os=darwin
-        elif [[ "$OSTYPE" =~ cygwin|mysys|win32 ]]; then
-            os=windows
+            os=mac
         else
             error "### $OSTYPE not supported"
             exit 1
@@ -48,13 +46,15 @@ function mjpeg_preview() {
         if [[ "$arch" == "x86_64" ]]; then
             goarch="amd64"
         elif [[ "$arch" == "i386" ]]; then
-            goarch="386"
+            goarch="i386"
         elif [[ "$arch" == "armv7l" ]]; then
-            goarch="armv7"
+            goarch="arm"
         elif [[ "$arch" == "armv6l" ]]; then
             goarch="armv6"
         elif [[ "$arch" == "aarch64" ]]; then
             goarch="arm64"
+        elif [[ "$arch" == "mips" ]]; then
+            goarch="mipsel"
         else
             error "### $arch not supported"
             exit 1
@@ -63,10 +63,8 @@ function mjpeg_preview() {
         if [[ ! -d /usr/local/bin ]]; then
             mkdir -p /usr/local/bin
         fi
-        file="go2rtc_${os}_${goarch}.tar.gz"
-        wget -P /tmp "https://github.com/dadav/go2rtc/releases/download/${GO2RTC_VERSION}/${file}"
-        tar xf "/tmp/${file}" -C /usr/local/bin go2rtc
-        rm /tmp/"$file"
+        file="go2rtc_${os}_${goarch}"
+        wget -O /usr/local/bin/go2rtc "https://github.com/AlexxIT/go2rtc/releases/download/${GO2RTC_VERSION}/${file}"
         chmod +x /usr/local/bin/go2rtc
     fi
 

--- a/scripts/install-go2rtc-preview.sh
+++ b/scripts/install-go2rtc-preview.sh
@@ -163,6 +163,25 @@ EOF
     fi
 }
 
+function uninstall() {
+    info "### Uninstalling the camera streaming service"
+
+    if systemctl is-active --quiet go2rtc.service; then
+        systemctl stop go2rtc.service
+    fi
+
+    systemctl disable go2rtc.service
+    rm -f /etc/systemd/system/go2rtc.service
+    systemctl daemon-reload
+
+    rm -f /etc/go2rtc.yaml
+    rm -f /usr/local/bin/go2rtc
+    rm -f /usr/local/bin/capture
+    rm -f /etc/sudoers.d/020_www-data-systemctl
+
+    info "### Uninstallation complete!"
+}
+
 info "Do you want to install a service to"
 info "be able to stream your camera to via?"
 info ""
@@ -170,9 +189,10 @@ echo "Your options are:"
 echo "1 Install go2rtc and needed service for gphoto2"
 echo "2 Install go2rtc and needed service for rpicam-apps"
 echo "3 Install go2rtc and needed service for libcamera-apps"
-echo "4 Do nothing"
+echo "4 Uninstall go2rtc and the related services"
+echo "5 Do nothing"
 info ""
-ask_yes_no "Please enter your choice:" "3"
+ask_yes_no "Please enter your choice:" "5"
 info ""
 if [[ $REPLY =~ ^[1]$ ]]; then
     info "### We will install a service to set up a mjpeg stream for gphoto2."
@@ -188,6 +208,9 @@ elif [[ $REPLY =~ ^[3]$ ]]; then
     CAPTURE_CMD="libcamera-still"
     CAPTURE_ARGS="-n -q 100 -t 1 -o \$1"
     NOTE="don't forget to add -o %s."
+elif [[ $REPLY =~ ^[4]$ ]]; then
+    uninstall
+    exit 0
 else
     info "Okay... doing nothing!"
     exit 0

--- a/scripts/install-go2rtc-preview.sh
+++ b/scripts/install-go2rtc-preview.sh
@@ -184,13 +184,15 @@ EOF
 function uninstall() {
     info "### Uninstalling the camera streaming service"
 
-    if systemctl is-active --quiet go2rtc.service; then
-        systemctl stop go2rtc.service
-    fi
+    if [[ -f /etc/systemd/system/go2rtc.service ]]; then
+        if systemctl is-active --quiet go2rtc.service; then
+            systemctl stop go2rtc.service
+        fi
 
-    systemctl disable go2rtc.service
-    rm -f /etc/systemd/system/go2rtc.service
-    systemctl daemon-reload
+        systemctl disable go2rtc.service
+        rm -f /etc/systemd/system/go2rtc.service
+        systemctl daemon-reload
+    fi
 
     rm -f /etc/go2rtc.yaml
     rm -f /usr/local/bin/go2rtc

--- a/scripts/install-go2rtc-preview.sh
+++ b/scripts/install-go2rtc-preview.sh
@@ -235,7 +235,7 @@ echo "4 Update go2rtc only (version: ${GO2RTC_VERSION})"
 echo "5 Uninstall go2rtc and the related services"
 echo "6 Do nothing"
 info ""
-ask_yes_no "Please enter your choice:" "6"
+ask_yes_no "Please enter your choice" "6"
 info ""
 if [[ $REPLY =~ ^[1]$ ]]; then
     info "### We will install a service to set up a mjpeg stream for gphoto2."
@@ -260,10 +260,10 @@ elif [[ $REPLY =~ ^[5]$ ]]; then
     uninstall
     exit 0
 else
-    info "Okay... doing nothing!"
+    info "### Okay... doing nothing!"
     exit 0
 fi
 
 mjpeg_preview
-info "Done!"
+info "### Done!"
 exit 0

--- a/scripts/install-go2rtc-preview.sh
+++ b/scripts/install-go2rtc-preview.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-GO2RTC_VERSION="v1.9.3"
+GO2RTC_VERSION="1.9.3"
 YAML_STREAM="dslr: exec:gphoto2 --capture-movie --stdout#killsignal=sigint"
 CAPTURE_CMD="gphoto2"
 CAPTURE_ARGS="--set-config output=Off --capture-image-and-download --filename=\$1"
@@ -87,7 +87,7 @@ function install_go2rtc() {
             mkdir -p /usr/local/bin
         fi
         file="go2rtc_${os}_${goarch}"
-        wget -O /usr/local/bin/go2rtc "https://github.com/AlexxIT/go2rtc/releases/download/${GO2RTC_VERSION}/${file}"
+        wget -O /usr/local/bin/go2rtc "https://github.com/AlexxIT/go2rtc/releases/download/v${GO2RTC_VERSION}/${file}"
         chmod +x /usr/local/bin/go2rtc
     fi
 

--- a/scripts/install-go2rtc-preview.sh
+++ b/scripts/install-go2rtc-preview.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 GO2RTC_VERSION="1.9.3"
-YAML_STREAM="dslr: exec:gphoto2 --capture-movie --stdout#killsignal=sigint"
+YAML_STREAM="photobooth: exec:gphoto2 --capture-movie --stdout#killsignal=sigint"
 CAPTURE_CMD="gphoto2"
 CAPTURE_ARGS="--set-config output=Off --capture-image-and-download --filename=\$1"
 NOTE="don't forget to add --filename=%s."
@@ -179,7 +179,7 @@ EOF
     info ""
     info "    Please adjust your Photobooth configuration:"
     info "    Preview mode: from URL"
-    info "    Preview-URL: url(\"http://localhost:1984/api/stream.mjpeg?src=dslr\")"
+    info "    Preview-URL: url(\"http://localhost:1984/api/stream.mjpeg?src=photobooth\")"
     info "    Take picture command: capture %s"
     warn "    Note: Countdown for pictures and collage should be set to a minimum of 6 seconds!"
     info ""
@@ -232,13 +232,13 @@ if [[ $REPLY =~ ^[1]$ ]]; then
     info "### We will install a service to set up a mjpeg stream for gphoto2."
 elif [[ $REPLY =~ ^[2]$ ]]; then
     info "### We will install a service to set up a mjpeg stream for rpicam-apps."
-    YAML_STREAM="dslr: exec:rpicam-vid -t 0 --codec mjpeg -o -#killsignal=sigint"
+    YAML_STREAM="photobooth: exec:rpicam-vid -t 0 --codec mjpeg -o -#killsignal=sigint"
     CAPTURE_CMD="rpicam-still"
     CAPTURE_ARGS="-n -q 100 -t 1 -o \$1"
     NOTE="don't forget to add -o %s."
 elif [[ $REPLY =~ ^[3]$ ]]; then
     info "### We will install a service to set up a mjpeg stream for libcamera-apps."
-    YAML_STREAM="dslr: exec:libcamera-vid -t 0 --codec mjpeg -o -#killsignal=sigint"
+    YAML_STREAM="photobooth: exec:libcamera-vid -t 0 --codec mjpeg -o -#killsignal=sigint"
     CAPTURE_CMD="libcamera-still"
     CAPTURE_ARGS="-n -q 100 -t 1 -o \$1"
     NOTE="don't forget to add -o %s."

--- a/scripts/install-go2rtc-preview.sh
+++ b/scripts/install-go2rtc-preview.sh
@@ -59,10 +59,12 @@ function install_go2rtc() {
     fi
 
     if [ "$install_bin" = true ]; then
+        is_zip=false
         if [[ "$OSTYPE" =~ linux ]]; then
             os=linux
         elif [[ "$OSTYPE" =~ darwin ]]; then
             os=mac
+            is_zip=true
         else
             error "### $OSTYPE not supported"
             exit 1
@@ -89,8 +91,15 @@ function install_go2rtc() {
         if [[ ! -d /usr/local/bin ]]; then
             mkdir -p /usr/local/bin
         fi
-        file="go2rtc_${os}_${goarch}"
-        wget -O /usr/local/bin/go2rtc "https://github.com/AlexxIT/go2rtc/releases/download/v${GO2RTC_VERSION}/${file}"
+        if [ "$is_zip" = true ]; then
+            file="go2rtc_${os}_${goarch}.zip"
+            wget -O /tmp/go2rtc.zip "https://github.com/AlexxIT/go2rtc/releases/download/v${GO2RTC_VERSION}/${file}"
+            unzip -p /tmp/go2rtc.zip go2rtc >/usr/local/bin/go2rtc
+            rm /tmp/go2rtc.zip
+        else
+            file="go2rtc_${os}_${goarch}"
+            wget -O /usr/local/bin/go2rtc "https://github.com/AlexxIT/go2rtc/releases/download/v${GO2RTC_VERSION}/${file}"
+        fi
         chmod +x /usr/local/bin/go2rtc
     fi
 

--- a/scripts/install-go2rtc-preview.sh
+++ b/scripts/install-go2rtc-preview.sh
@@ -4,6 +4,7 @@ GO2RTC_VERSION="v1.8.6-4"
 YAML_STREAM="dslr: exec:gphoto2 --capture-movie --stdout#killsignal=sigint"
 CAPTURE_CMD="gphoto2"
 CAPTURE_ARGS="--set-config output=Off --capture-image-and-download --filename=\$1"
+NOTE="don't forget to add --filename=%s."
 
 function info {
     echo -e "\033[0;36m${1}\033[0m"
@@ -120,7 +121,7 @@ Usage:
     capture <filename> [or all required $CAPTURE_CMD arguments]
 
 In photobooth, usually 'capture %s' is enough. But if you want to use a more complex command,
-don't forget to add --filename=%s.
+$NOTE
 
 HELP
   exit 0
@@ -180,11 +181,13 @@ elif [[ $REPLY =~ ^[2]$ ]]; then
     YAML_STREAM="dslr: exec:rpicam-vid -t 0 --codec mjpeg -o -#killsignal=sigint"
     CAPTURE_CMD="rpicam-still"
     CAPTURE_ARGS="-n -q 100 -t 1 -o \$1"
+    NOTE="don't forget to add -o %s."
 elif [[ $REPLY =~ ^[3]$ ]]; then
     info "### We will install a service to set up a mjpeg stream for libcamera-apps."
     YAML_STREAM="dslr: exec:libcamera-vid -t 0 --codec mjpeg -o -#killsignal=sigint"
     CAPTURE_CMD="libcamera-still"
     CAPTURE_ARGS="-n -q 100 -t 1 -o \$1"
+    NOTE="don't forget to add -o %s."
 else
     info "Okay... doing nothing!"
     exit 0

--- a/scripts/install-go2rtc-preview.sh
+++ b/scripts/install-go2rtc-preview.sh
@@ -49,7 +49,7 @@ function install_go2rtc() {
         install_bin=true
     fi
 
-    if [ "$install_bin" = true ]; then 
+    if [ "$install_bin" = true ]; then
         if [[ "$OSTYPE" =~ linux ]]; then
             os=linux
         elif [[ "$OSTYPE" =~ darwin ]]; then


### PR DESCRIPTION
- seperate installation of go2rtc preview from main installer
- remove preview via cameracontrol.py from main installer: Pi Camera user frequently used this option by accident
- added rpicam-apps and libcamera-apps support for go2rtc
-  allow update of go2rtc
- allow to uninstall go2rtc and related services
- adjusted the FAQ and removed old workarounds for PiCamera
- update go2rtc, switch to official release (closes https://github.com/PhotoboothProject/photobooth/pull/705)
- rename go2rtc src from dslr to photobooth