### PR TITLE
fix(DatabaseManagerService): fix unhandled type error

### DIFF
--- a/src/Service/DatabaseManagerService.php
+++ b/src/Service/DatabaseManagerService.php
@@ -38,7 +38,12 @@ class DatabaseManagerService
                 if ($data === false) {
                     throw new \Exception('Failed to read file: ' . $this->databaseFile);
                 }
-                return json_decode($data);
+                $decodedData = json_decode($data, true);
+                if (json_last_error() !== JSON_ERROR_NONE) {
+                    throw new \Exception('Failed to decode JSON: ' . json_last_error_msg());
+                }
+
+                return is_array($decodedData) ? $decodedData : [];
             } else {
                 throw new \Exception('File not found: ' . $this->databaseFile);
             }


### PR DESCRIPTION
```
Fatal error: Uncaught TypeError: 
Photobooth\Service\DatabaseManagerService::getContentFromDB():
Return value must be of type array, null returned in 
/var/www/html/src/Service/DatabaseManagerService.php:41 Stack trace: #0 
/var/www/html/template/components/main.defaults.php(8): 
Photobooth\Service\DatabaseManagerService->getContentFromDB()
#1 /var/www/html/template/components/main.head.php(9): include('...')
#2 /var/www/html/index.php(39): include('...') 
#3 {main} thrown
in /var/www/html/src/Service/DatabaseManagerService.php on line 41
```