### PR TITLE
install-gphoto-python: Added choice to create a service instead of the cron job for virtual-device cam

### DIFF
--- a/scripts/install-gphoto-python.sh
+++ b/scripts/install-gphoto-python.sh
@@ -29,20 +29,24 @@ function ask_yes_no {
     read -p "${1}: " -n 1 -r
 }
 
-function add_cronjob() {
+function get_camaracontrol_path() {
     path1="/var/www/html/api/cameracontrol.py"
     path2="/var/www/html/photobooth/api/cameracontrol.py"
 
     # Check if cameracontrol.py exists
     if [ -f "$path1" ]; then
-         script_path="$path1"
+        script_path="$path1"
     elif [ -f "$path2" ]; then
         script_path="$path2"
     else
         error "### Error: Neither $path1 nor $path2 exists."
-        error "### Can not create cronjob for www-data user!"
+        error "${1}"
         exit 1
     fi
+}
+
+function add_cronjob() {
+    get_camaracontrol_path "### Can not create cronjob for www-data user!"
 
     cron_job="@reboot /usr/bin/python3 $script_path -b"
     current_crontab=$(sudo -u www-data crontab -l 2>/dev/null)
@@ -88,6 +92,44 @@ function clean_service() {
     fi
 }
 
+function create_ffmpeg_webcam_service() {
+    get_camaracontrol_path "### Can not create ffmpeg-webcam.service!"
+    info "### Create Service for running CameraControl Daemon..."
+    cat >/etc/systemd/system/ffmpeg-webcam.service <<EOF
+[Unit]
+Description=ffmpeg webcam service
+
+[Service]
+Type=simple
+RemainAfterExit=no
+ExecStart=/usr/bin/python3 $script_path --forceRecreateCam
+ExecStop=/usr/bin/python3 $script_path --exit
+
+[Install]
+WantedBy=multi-user.target
+EOF
+    info "### Created Service ffmpeg-webcam.service"
+    systemctl daemon-reload
+    systemctl enable ffmpeg-webcam.service
+    systemctl start ffmpeg-webcam.service
+}
+
+function persist_webcam() {
+    info "### Persists Webcam to survive reboot..."
+    info "    You can use a cronjob or a systemd service to recreate/restart Webcam after reboot."
+    info "    Using the Service might be more robust, it runs as root and reloads the kernel modules on start."
+    echo "Your choices are:"
+    echo "1 create a cronjob"
+    echo "2 create a service"
+    ask_yes_no "Please enter your choice" "1"
+    info ""
+    if [[ $REPLY =~ ^[1]$ ]]; then
+        add_cronjob
+    elif [[ $REPLY =~ ^[2]$ ]]; then
+        create_ffmpeg_webcam_service
+    fi
+}
+
 info "This script installs some dependencies and simplifies the setup for using gphoto2 as webcam."
 info "It installs required dependencies and sets up a virtual webcam that gphoto2 can stream video to."
 info "It can remove the gphoto2 webcam setup, as well."
@@ -95,8 +137,9 @@ info ""
 echo "Your options are:"
 echo "1 Install gphoto2 webcam"
 echo "2 Remove gphoto2 webcam"
-echo "3 Migrate from systemd service to modprobe config"
-echo "4 Nothing"
+echo "3 Migrate from systemd service to modprobe/cronjob config"
+echo "4 Migrate from cronjob service to modprobe/systemd config"
+echo "5 Nothing"
 info ""
 ask_yes_no "Please enter your choice" "3"
 info ""
@@ -136,7 +179,7 @@ EOF
         info "    Take picture command: python3 cameracontrol.py --capture-image-and-download %s"
         info ""
         info "### Trying to create needed cronjob ..."
-        add_cronjob
+        persist_webcam
         exit 0
     fi
 elif [[ $REPLY =~ ^[2]$ ]]; then
@@ -152,6 +195,12 @@ elif [[ $REPLY =~ ^[3]$ ]]; then
     clean_service
     info "### Trying to create needed cronjob ..."
     add_cronjob
+elif [[ $REPLY =~ ^[4]$ ]]; then
+    info "### Migrating to modprobe config"
+    gphoto_preview
+    remove_cronjob
+    info "### Trying to create needed service ..."
+    create_ffmpeg_webcam_service
 else
     info "### Okay... doing nothing!"
 fi


### PR DESCRIPTION
#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/PhotoboothProject/photobooth/blob/dev/CONTRIBUTING.md).

#### What is the purpose of this pull request?

- [ ] Documentation update
- [x] Bug fix
- [ ] New feature
- [ ] Other, please explain:

#### What changes did you make? (Give an overview)
I've had some issues with the new modprobe/cronjob setup. Modprobe didn't create the virtual webcam on RPi4.
As the cronjob is configured to run as user www-data, it could not execute modprobe to create the virtual webcam.
I'm not sure why the service setup was purged, but in order to get things working, i've created a new service, which starts the CameraControl daemon using the new `cameracontrol.py`.
Another problem I've had with the virtual webcam was, an error which I've got when ffmpeg was restarted:
```
[video4linux2,v4l2 @ 0x55d2beacf0] ioctl(VIDIOC_G_FMT): Invalid argument
Could not write header for output file #0 (incorrect codec parameters ?): Invalid argument
Error initializing output stream 0:0 --
```

After re-crating the virtual webcam using rmmod and modprobe the camera was working again. So I've implemented the `--forceRecreateCam` command line argument, which removes the webcam kernel module and reloads them. This option requires `cameracontrol.py` to be executed as root.


#### Is there anything you'd like reviewers to focus on?
This update only affects installations where the user selects virtual webcam persistence using a systemd service. It is no revert to the legacy service which used the legacy cameracontrol.py. The created service starts the CameraControl daemon from the new cameracontrol.py. The kernel modules are reloaded at each service start, which also shouldn't lead to any issues.

I've also set the check for the `v4l2-ctl --list-devices` command to false, as the execution of it exits with an error because it cannot open `/dev/video0`:
```
$ v4l2-ctl --list-devices
bcm2835-codec-decode (platform:bcm2835-codec):
	/dev/video10
	/dev/video11
	/dev/video12
	/dev/video18
	/dev/video31
	/dev/media1

rpivid (platform:rpivid):
	/dev/video19
	/dev/media0

Gphoto2 Webcam (platform:v4l2loopback-000):
	/dev/video9

Cannot open device /dev/video0, exiting.
```
As this is not the virtual webcam, this is no real issue.