### PR TITLE
serverInfo: convert objects inside array to json string

### DIFF
--- a/api/serverInfo.php
+++ b/api/serverInfo.php
@@ -125,7 +125,9 @@ function processItem(string $key, mixed $content): array
 
     if (isset($content)) {
         if (is_array($content)) {
-            $contentString = implode(', ', $content);
+            $contentString = implode(', ', array_map(function ($item) {
+                return is_object($item) ? json_encode($item) : $item;
+            }, $content));
             $output[] = "Value:     $contentString";
         } elseif (is_bool($content)) {
             $contentString = $content ? 'true' : 'false';


### PR DESCRIPTION
Fix

```
Fatal error:  Uncaught Error: Object of class Photobooth\Enum\ImageFilterEnum could not be converted to string in /var/www/html/api/serverInfo.php:128
Stack trace:
#0 /var/www/html/api/serverInfo.php(128): implode()
#1 /var/www/html/api/serverInfo.php(156): processItem()
#2 /var/www/html/api/serverInfo.php(22): showConfig()
#3 /var/www/html/api/serverInfo.php(197): handleDebugPanel()
#4 {main}
  thrown in /var/www/html/api/serverInfo.php on line 128
```