### PR TITLE
docs:  Changed name of start-up batch file for Windows

### DIFF
--- a/docs/install/install-windows.md
+++ b/docs/install/install-windows.md
@@ -68,7 +68,7 @@ the wsl machine.
 Press `WIN+R` and run `shell:startup`. This will open the startup directory in your
 explorer.
 
-Create a file named `wsl.bat` with this content (adjust the `BUSID`):
+Create a file named `wsl_start.bat` with this content (adjust the `BUSID`):
 
 ```bat
 wsl --exec dbus-launch true


### PR DESCRIPTION
<!--
    Thank you for contributing!
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/PhotoboothProject/photobooth/blob/dev/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "x" next to an item)
<!-- Example:
- [x] Bug fix
-->

- [x] Documentation update
- [ ] Bug fix
- [ ] New feature
- [ ] Other, please explain:

<!--
    Please ensure your pull request is ready:

    - Please run 'npm run build' before submitting to have consistent formatting for both JavaScript & SCSS
    - Please run 'npm run eslint' to make sure there's no lint issues
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

- Changed the proposed name for the start-up batch file for Windows to `wsl_start.bat`, the current `wsl.bat` will lead the script calling itself over and over again

