### PR TITLE
admin: show tooltips on touch devices

### DIFF
--- a/assets/sass/tailwind.admin.scss
+++ b/assets/sass/tailwind.admin.scss
@@ -1,5 +1,6 @@
 @use '../../node_modules/tailwindcss';
 @config "../../config/tailwind.admin.config.mjs";
+@custom-variant hover (&:hover);
 
 body {
   width: 100%;


### PR DESCRIPTION
In tailwind-css v4 the hover variant was updated to only apply when the primary input device supports hover.
Override the hover variant to use the old implementation triggering hover on tap.

https://tailwindcss.com/docs/upgrade-guide#hover-styles-on-mobile