### PR TITLE
bugfix: ensure live preview is not cached

### DIFF
--- a/admin/captureconfig.php
+++ b/admin/captureconfig.php
@@ -34,7 +34,7 @@ $config['commands']['take_picture'] = 'capture %s';
 $config['picture']['cheese_time'] = '0';
 
 $config['preview']['mode'] = 'url';
-$config['preview']['url'] = 'url("http://' . Environment::getIp() . ':1984/api/stream.mjpeg?src=photobooth")';
+$config['preview']['url'] = 'http://' . Environment::getIp() . ':1984/api/stream.mjpeg?src=photobooth';
 $config['preview']['camTakesPic'] = false;
 
 try {

--- a/admin/wgetcaptureconfig.php
+++ b/admin/wgetcaptureconfig.php
@@ -34,7 +34,7 @@ $config['commands']['take_picture'] = 'wget -O %s http://' . Environment::getIp(
 $config['picture']['cheese_time'] = '0';
 
 $config['preview']['mode'] = 'url';
-$config['preview']['url'] = 'url("http://' . Environment::getIp() . ':1984/api/stream.mjpeg?src=photobooth")';
+$config['preview']['url'] = 'http://' . Environment::getIp() . ':1984/api/stream.mjpeg?src=photobooth';
 $config['preview']['camTakesPic'] = false;
 
 try {

--- a/assets/js/preview.js
+++ b/assets/js/preview.js
@@ -1,5 +1,22 @@
 /* eslint n/no-unsupported-features/node-builtins: "off" */
 /* globals photoBooth photoboothTools */
+
+function addCacheBustingParam(url) {
+    const timestamp = new Date().getTime();
+
+    if (url.includes('?')) {
+        return `${url}&t=${timestamp}`;
+    }
+
+    return `${url}?t=${timestamp}`;
+}
+
+function getRootProperty(property) {
+    const root = document.documentElement;
+    const style = getComputedStyle(root);
+    return style.getPropertyValue(property).trim();
+}
+
 const photoboothPreview = (function () {
     // vars
     const CameraDisplayMode = {
@@ -163,8 +180,8 @@ const photoboothPreview = (function () {
                 } else if (config.preview.mode === PreviewMode.URL.valueOf()) {
                     photoboothTools.console.logDev('Preview: Preview at countdown from URL.');
                     setTimeout(function () {
+                        url.attr('src', addCacheBustingParam(getRootProperty('--background-preview')));
                         url.show();
-                        url.addClass('streaming');
                     }, config.preview.url_delay);
                 }
                 break;
@@ -175,8 +192,8 @@ const photoboothPreview = (function () {
                 } else if (config.preview.mode === PreviewMode.URL.valueOf()) {
                     photoboothTools.console.logDev('Preview: Preview from URL.');
                     setTimeout(function () {
+                        url.attr('src', addCacheBustingParam(getRootProperty('--background-preview')));
                         url.show();
-                        url.addClass('streaming');
                     }, config.preview.url_delay);
                 }
                 break;
@@ -201,8 +218,8 @@ const photoboothPreview = (function () {
             api.stream.getTracks()[0].stop();
             api.stream = null;
         }
-        url.removeClass('streaming');
         url.hide();
+        url.attr('src', '');
         video.hide();
         pictureFrame.hide();
         collageFrame.hide();

--- a/assets/js/test-preview.js
+++ b/assets/js/test-preview.js
@@ -96,7 +96,7 @@ const photoboothPreviewTest = (function () {
         if (config.preview.mode === PreviewMode.DEVICE.valueOf()) {
             photoboothPreview.stopVideo();
         } else if (config.preview.mode === PreviewMode.URL.valueOf()) {
-            previewIpcam.removeClass('streaming');
+            previewIpcam.attr('src', '');
             previewIpcam.hide();
         }
 

--- a/assets/sass/components/_preview.scss
+++ b/assets/sass/components/_preview.scss
@@ -92,9 +92,3 @@
     scale: 1 -1;
   }
 }
-
-#preview--ipcam {
-  &.streaming {
-    background-image: var(--background-preview);
-  }
-}

--- a/docs/faq/index.md
+++ b/docs/faq/index.md
@@ -468,7 +468,7 @@ If you like to have the same preview independent of the device you access Photob
 Make sure to have a stream available you can use (e.g. from your Webcam, Smartphone Camera or Raspberry Pi Camera)
 
 -   Admin panel config _"Preview mode"_: `from URL`
--   Admin panel config _"Preview-URL"_ example (add needed IP address instead): `url(http://192.168.0.2:8081)`
+-   Admin panel config _"Preview-URL"_ example (add needed IP address instead): `http://192.168.0.2:8081`
 
 **Note**
 
@@ -480,7 +480,7 @@ Make sure to have a stream available you can use (e.g. from your Webcam, Smartph
 
 If you want to use a stream from your DSLR or Pi Camera, install go2rtc and setup needed service to use.
 
-go2rtc can be accessed at `http://localhost:1984`. Use `url("http://localhost:1984/api/stream.mjpeg?src=photobooth")` as _"Preview-URL"_ (replace `localhost` with Photobooths IP for remote access).
+go2rtc can be accessed at `http://localhost:1984`. Use `http://localhost:1984/api/stream.mjpeg?src=photobooth` as _"Preview-URL"_ (replace `localhost` with Photobooths IP for remote access).
 To be able to also capture images you need to adjust the capture command.
 _"Commands"_: _"Take picture command"_: `capture %s`
 

--- a/lib/configsetup.inc.php
+++ b/lib/configsetup.inc.php
@@ -1365,7 +1365,7 @@ return [
         'preview_url' => [
             'type' => 'input',
             'name' => 'preview[url]',
-            'placeholder' => 'url(http://localhost:8081)',
+            'placeholder' => 'http://localhost:8081',
             'value' => htmlentities($config['preview']['url'] ?? ''),
         ],
         'preview_url_delay' => [

--- a/src/Service/ConfigurationService.php
+++ b/src/Service/ConfigurationService.php
@@ -161,6 +161,11 @@ class ConfigurationService
             $config['preview']['mode'] = 'device_cam';
         }
 
+        // Migrate Preview URL
+        if (isset($config['preview']['url']) && substr($config['preview']['url'], 0, 4) === 'url(' && substr($config['preview']['url'], -1) === ')') {
+            $config['preview']['url'] = trim(substr($config['preview']['url'], 4, -1), '"\'');
+        }
+
         return $config;
     }
 

--- a/template/components/preview.php
+++ b/template/components/preview.php
@@ -44,7 +44,7 @@ echo '<div class="preview">';
 echo '<div id="preview-container" style="aspect-ratio: ' . $comp . '">';
 echo '<div id="preview-wrapper" style="aspect-ratio:' . $comp . '">';
 echo '<video id="preview--video" style="' . $composed_style . '" class="' . $previewFlipClass . ' ' . $previewStyleClass . '" autoplay playsinline></video>';
-echo '<div id="preview--ipcam" style="' . $composed_style . '" class="' . $previewFlipClass . ' ' . $previewStyleClass . '"></div>';
+echo '<img id="preview--ipcam" style="' . $composed_style . '" class="' . $previewFlipClass . ' ' . $previewStyleClass . '"></img>';
 echo '<div id="preview--none">' . $languageService->translate('no_preview') . '</div>';
 echo '</div></div>';
 


### PR DESCRIPTION
I use a setup with a live preview showing an MJPEG-based stream created by Go2rtc during the countdown. When using an iPad to control the photobooth, the preview works fine when taking a picture. However, when I click the `newPhoto` button on the results page, only the last frame of the previous live stream is shown. Everything works fine when I use Firefox on Windows. I think this is exactly the same issue as described in #942.
It seems that Safari (iOS 17.7.10) and Chrome (141.0.7390.41) on the iPad cache the last frame when the `preview--ipcam` element is hidden, and only use this frame when it is shown again instead of fetching the stream.

<!--
    Thank you for contributing!
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/PhotoboothProject/photobooth/blob/dev/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "x" next to an item)
<!-- Example:
- [x] Bug fix
-->

- [ ] Documentation update
- [x] Bug fix
- [ ] New feature
- [ ] Other, please explain:

<!--
    Please ensure your pull request is ready:

    - Please run 'npm run build' before submitting to have consistent formatting for both JavaScript & SCSS
    - Please run 'npm run eslint' to make sure there's no lint issues
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

It seems that caching cannot be disabled for background images applied to `div` elements.  
As a workaround, I added a cache-busting query parameter to the stream URL so that it’s unique each time the `preview--ipcam` element is shown.

To simplify handling the stream source, I changed the `preview--ipcam` element from a `div` with a CSS background image to an `<img>` element. This allows the stream URL to be passed directly via the `src` attribute instead of using `url('...')`.  
A timestamp (`t=<timestamp>`) is appended to the URL to ensure it’s different each time and therefore not cached by the browser.

##### Tested on
- Firefox 143.0.4 (Windows)
- Safari (iOS 17.7.10)
- Chrome 141.0.7390.41 (iOS 17.7.10)
- Chrome 141.0.7390.122 (Android 15)

##### Note
The stream URL must now be passed directly to the `<img>` element; the `url('...')` syntax is no longer needed.


#### Is there anything you'd like reviewers to focus on?
As I’m not a JS/PHP developer, I’d appreciate it if you could check whether I’ve missed any best practices or made any mistakes in the implementation. Please feel free to point out any issues with the code, especially if something seems unconventional or my implementation causes problems I am not aware of.