### PR TITLE
fix wrong preview test btn

### DIFF
--- a/assets/js/test-preview.js
+++ b/assets/js/test-preview.js
@@ -74,11 +74,7 @@ const photoboothPreviewTest = (function () {
         photoboothPreview.startVideo(CameraDisplayMode.TEST);
 
         setTimeout(() => {
-            if (photoboothPreview.stream) {
-                buttonStopPreview.show();
-            } else {
-                buttonStartPreview.show();
-            }
+            buttonStopPreview.show();
         }, 4000);
     });
 


### PR DESCRIPTION
… so wrong btn was shown).

<!--
    Thank you for contributing!
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/PhotoboothProject/photobooth/blob/dev/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "x" next to an item)
<!-- Example:
- [x] Bug fix
-->

- [ ] Documentation update
- [x] Bug fix
- [ ] New feature
- [ ] Other, please explain:

<!--
    Please ensure your pull request is ready:

    - Please run 'npm run build' before submitting to have consistent formatting for both JavaScript & SCSS
    - Please run 'npm run eslint' to make sure there's no lint issues
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)
If we are on url, the wrong preview test stop btn is shown (always start preview), causing in not stopping url streams.


#### Is there anything you'd like reviewers to focus on?
