### PR TITLE
add clear cache on reload btn click

### DIFF
--- a/assets/js/tools.js
+++ b/assets/js/tools.js
@@ -303,7 +303,9 @@ const photoboothTools = (function () {
     };
 
     api.reloadPage = function () {
-        window.location.reload();
+        const url = new URL(window.location.href);
+        url.searchParams.set('refresh', '1');
+        window.location.href = url.toString();
     };
 
     api.getRequest = function (url) {

--- a/index.php
+++ b/index.php
@@ -8,6 +8,20 @@ use Photobooth\Service\ProcessService;
 use Photobooth\Utility\PathUtility;
 
 $assetService = AssetService::getInstance();
+$noCacheFlag = !empty($_GET['refresh']);
+
+if (!isset($_SESSION['asset_extra_version'])) {
+    $_SESSION['asset_extra_version'] = '';
+}
+
+if ($noCacheFlag) {
+    // neuen Hash erzeugen und merken
+    $_SESSION['asset_extra_version'] = (string) time();
+    header('Cache-Control: no-store, no-cache, must-revalidate, max-age=0');
+    header('Pragma: no-cache');
+}
+
+$assetService->setExtraVersion($_SESSION['asset_extra_version'] ?: null);
 
 if (!$config['ui']['skip_welcome']) {
     if (!is_file(PathUtility::getAbsolutePath('welcome/.skip_welcome'))) {
@@ -89,5 +103,19 @@ if ($config['ui']['selfie_mode']) {
 
 <?php include PathUtility::getAbsolutePath('template/components/start.adminshortcut.php'); ?>
 <?php ProcessService::getInstance()->boot(); ?>
+
+<?php if ($noCacheFlag): ?>
+<script>
+    (function () {
+        try {
+            const url = new URL(window.location.href);
+            url.searchParams.delete('refresh');
+            window.history.replaceState(null, '', url.toString());
+        } catch (e) {
+            // ignore
+        }
+    })();
+</script>
+<?php endif; ?>
 </body>
 </html>

--- a/index.php
+++ b/index.php
@@ -15,7 +15,6 @@ if (!isset($_SESSION['asset_extra_version'])) {
 }
 
 if ($noCacheFlag) {
-    // neuen Hash erzeugen und merken
     $_SESSION['asset_extra_version'] = (string) time();
     header('Cache-Control: no-store, no-cache, must-revalidate, max-age=0');
     header('Pragma: no-cache');

--- a/src/Service/AssetService.php
+++ b/src/Service/AssetService.php
@@ -9,6 +9,7 @@ use Symfony\Component\Asset\Packages;
 class AssetService
 {
     protected Packages $packages;
+    protected ?string $extraVersion = null;
 
     public function __construct()
     {
@@ -18,7 +19,19 @@ class AssetService
 
     public function getUrl(string $path): string
     {
-        return $this->packages->getUrl($path);
+        $url = $this->packages->getUrl($path);
+
+        if ($this->extraVersion !== null && $this->extraVersion !== '') {
+            $separator = str_contains($url, '?') ? '&' : '?';
+            $url .= $separator . 'r=' . rawurlencode($this->extraVersion);
+        }
+
+        return $url;
+    }
+
+    public function setExtraVersion(?string $version): void
+    {
+        $this->extraVersion = $version;
     }
 
     public static function getInstance(): self


### PR DESCRIPTION
<!--
    Thank you for contributing!
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/PhotoboothProject/photobooth/blob/dev/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "x" next to an item)
<!-- Example:
- [x] Bug fix
-->

- [ ] Documentation update
- [ ] Bug fix
- [x] New feature
- [ ] Other, please explain:

<!--
    Please ensure your pull request is ready:

    - Please run 'npm run build' before submitting to have consistent formatting for both JavaScript & SCSS
    - Please run 'npm run eslint' to make sure there's no lint issues
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)
Sometimes during an event, after several hours, the captured preview screen becomes visually broken due to a CSS issue. It’s difficult to reproduce because it has only happened twice and appears to occur completely at random.

Restarting the iOS kiosk app temporarily resolved the issue.

This PR adds a clear cache functionality that reloads all assets without using the cache, in case any cached files become corrupted.


#### Is there anything you'd like reviewers to focus on?
