### PR TITLE
Cache gallery image dimensions to avoid repeated getimagesize calls

### DIFF
--- a/api/admin.php
+++ b/api/admin.php
@@ -10,6 +10,7 @@ use Photobooth\Enum\FolderEnum;
 use Photobooth\Environment;
 use Photobooth\Service\ConfigurationService;
 use Photobooth\Service\DatabaseManagerService;
+use Photobooth\Service\ImageMetadataCacheService;
 use Photobooth\Service\LoggerService;
 use Photobooth\Service\MailService;
 use Photobooth\Service\PrintManagerService;
@@ -78,6 +79,10 @@ if ($action === 'reset') {
             unlink($database->databaseFile);
             $logger->debug($database->databaseFile . ' deleted.');
         }
+
+        // Clear gallery image metadata cache as media has been removed
+        ImageMetadataCacheService::getInstance()->clear();
+        $logger->debug('Image metadata cache cleared.');
     }
 
     // Remove print database

--- a/api/chromakeying/save.php
+++ b/api/chromakeying/save.php
@@ -10,6 +10,7 @@ use Photobooth\Enum\ImageFilterEnum;
 use Photobooth\FileDelete;
 use Photobooth\PhotoboothCapture;
 use Photobooth\Service\DatabaseManagerService;
+use Photobooth\Service\ImageMetadataCacheService;
 use Photobooth\Service\LoggerService;
 use Photobooth\Utility\ImageUtility;
 
@@ -62,6 +63,10 @@ if ($saveCopy) {
             $delete = new FileDelete($_POST['file'], $paths);
             $delete->deleteFiles();
             $logger->debug('delete', $delete->getLogData());
+
+            // Remove cached metadata for this file and its thumb, if present
+            ImageMetadataCacheService::getInstance()->remove(FolderEnum::IMAGES->absolute() . DIRECTORY_SEPARATOR . $_POST['file']);
+            ImageMetadataCacheService::getInstance()->remove(FolderEnum::THUMBS->absolute() . DIRECTORY_SEPARATOR . $_POST['file']);
         }
     }
 }

--- a/api/deletePhoto.php
+++ b/api/deletePhoto.php
@@ -7,6 +7,7 @@ require_once '../lib/boot.php';
 use Photobooth\Enum\FolderEnum;
 use Photobooth\FileDelete;
 use Photobooth\Service\DatabaseManagerService;
+use Photobooth\Service\ImageMetadataCacheService;
 use Photobooth\Service\LoggerService;
 use Photobooth\Service\RemoteStorageService;
 
@@ -47,6 +48,10 @@ if ($config['database']['enabled']) {
     $database = DatabaseManagerService::getInstance();
     $database->deleteContentFromDB($file);
 }
+
+// Remove cached metadata for this file and its thumb, if present
+ImageMetadataCacheService::getInstance()->remove(FolderEnum::IMAGES->absolute() . DIRECTORY_SEPARATOR . $file);
+ImageMetadataCacheService::getInstance()->remove(FolderEnum::THUMBS->absolute() . DIRECTORY_SEPARATOR . $file);
 
 if ($config['ftp']['enabled'] && $config['ftp']['delete']) {
     $remoteStorage->delete($remoteStorage->getStorageFolder() . '/images/' . $file);

--- a/src/Image.php
+++ b/src/Image.php
@@ -3,6 +3,7 @@
 namespace Photobooth;
 
 use GdImage;
+use Photobooth\Service\ImageMetadataCacheService;
 use Photobooth\Utility\FontUtility;
 use Photobooth\Utility\ImageUtility;
 use Photobooth\Utility\PathUtility;
@@ -423,6 +424,11 @@ class Image
             if (!imagejpeg($sourceResource, $destination, $this->jpegQuality)) {
                 throw new \Exception('Error saving image.');
             }
+
+            // Cache image dimensions for gallery/PhotoSwipe performance
+            $width = imagesx($sourceResource);
+            $height = imagesy($sourceResource);
+            ImageMetadataCacheService::getInstance()->set($destination, $width, $height);
 
             return true;
         } catch (\Exception $e) {

--- a/src/Service/ImageMetadataCacheService.php
+++ b/src/Service/ImageMetadataCacheService.php
@@ -1,0 +1,129 @@
+<?php
+
+namespace Photobooth\Service;
+
+use Photobooth\Enum\FolderEnum;
+
+class ImageMetadataCacheService
+{
+    private const CACHE_FILE = 'image_metadata_cache.json';
+
+    /** @var array<string, array{width:int,height:int}> */
+    private array $cache = [];
+
+    private bool $dirty = false;
+
+    public function __construct()
+    {
+        $cacheFile = $this->getCacheFilePath();
+        if (is_file($cacheFile)) {
+            $data = file_get_contents($cacheFile);
+            if ($data !== false) {
+                $decoded = json_decode($data, true);
+                if (is_array($decoded)) {
+                    $this->cache = array_reduce(
+                        array_keys($decoded),
+                        function (array $carry, string $key) use ($decoded): array {
+                            $value = $decoded[$key];
+                            if (
+                                is_array($value)
+                                && isset($value['width'], $value['height'])
+                                && is_int($value['width'])
+                                && is_int($value['height'])
+                            ) {
+                                $carry[$key] = [
+                                    'width' => $value['width'],
+                                    'height' => $value['height'],
+                                ];
+                            }
+                            return $carry;
+                        },
+                        []
+                    );
+                }
+            }
+        }
+    }
+
+    public function __destruct()
+    {
+        $this->flush();
+    }
+
+    private function getCacheFilePath(): string
+    {
+        return FolderEnum::DATA->absolute() . DIRECTORY_SEPARATOR . self::CACHE_FILE;
+    }
+
+    public function get(string $path): ?array
+    {
+        return $this->cache[$path] ?? null;
+    }
+
+    public function set(string $path, int $width, int $height): void
+    {
+        $existing = $this->cache[$path] ?? null;
+        if ($existing !== null && $existing['width'] === $width && $existing['height'] === $height) {
+            return;
+        }
+
+        $this->cache[$path] = [
+            'width' => $width,
+            'height' => $height,
+        ];
+        $this->dirty = true;
+    }
+
+    /**
+     * Remove a single entry from the cache and persist change.
+     */
+    public function remove(string $path): void
+    {
+        if (!isset($this->cache[$path])) {
+            return;
+        }
+
+        unset($this->cache[$path]);
+        $this->dirty = true;
+        $this->flush();
+    }
+
+    /**
+     * Clear the whole cache file and in-memory cache.
+     */
+    public function clear(): void
+    {
+        $this->cache = [];
+        $this->dirty = false;
+
+        $cacheFile = $this->getCacheFilePath();
+        if (is_file($cacheFile)) {
+            @unlink($cacheFile);
+        }
+    }
+
+    private function flush(): void
+    {
+        if (!$this->dirty) {
+            return;
+        }
+
+        $cacheFile = $this->getCacheFilePath();
+        $encoded = json_encode($this->cache);
+        if ($encoded === false) {
+            return;
+        }
+
+        @file_put_contents($cacheFile, $encoded);
+        $this->dirty = false;
+    }
+
+    public static function getInstance(): self
+    {
+        if (!isset($GLOBALS[self::class])) {
+            $GLOBALS[self::class] = new self();
+        }
+
+        return $GLOBALS[self::class];
+    }
+}

--- a/template/components/gallery.images.php
+++ b/template/components/gallery.images.php
@@ -2,9 +2,11 @@
 
 use Photobooth\Enum\FolderEnum;
 use Photobooth\Service\LanguageService;
+use Photobooth\Service\ImageMetadataCacheService;
 use Photobooth\Utility\PathUtility;
 
 $languageService = LanguageService::getInstance();
+$metadataCache = ImageMetadataCacheService::getInstance();
 
 if (empty($imagelist)) {
     echo '<h1>' . $languageService->translate('gallery_no_image') . '</h1>';
@@ -29,19 +31,40 @@ if (empty($imagelist)) {
             $filename_photo = PathUtility::getAbsolutePath(FolderEnum::IMAGES->value . DIRECTORY_SEPARATOR . $image);
             $filename_thumb = PathUtility::getAbsolutePath(FolderEnum::THUMBS->value . DIRECTORY_SEPARATOR . $image);
 
-            $imageinfo = @getimagesize($filename_photo);
-            $imageinfoThumb = @getimagesize($filename_thumb);
+            $imageinfo = $metadataCache->get($filename_photo);
+            if ($imageinfo === null) {
+                $rawInfo = @getimagesize($filename_photo);
+                if (is_array($rawInfo)) {
+                    $imageinfo = [
+                        'width' => (int) $rawInfo[0],
+                        'height' => (int) $rawInfo[1],
+                    ];
+                    $metadataCache->set($filename_photo, $imageinfo['width'], $imageinfo['height']);
+                }
+            }
+
+            $imageinfoThumb = $metadataCache->get($filename_thumb);
+            if ($imageinfoThumb === null) {
+                $rawThumbInfo = @getimagesize($filename_thumb);
+                if (is_array($rawThumbInfo)) {
+                    $imageinfoThumb = [
+                        'width' => (int) $rawThumbInfo[0],
+                        'height' => (int) $rawThumbInfo[1],
+                    ];
+                    $metadataCache->set($filename_thumb, $imageinfoThumb['width'], $imageinfoThumb['height']);
+                }
+            }
 
             if (is_array($imageinfo)) {
                 if (!is_array($imageinfoThumb)) {
                     $imageinfoThumb = $imageinfo;
                 }
-                echo '<a href="' . PathUtility::getPublicPath($filename_photo) . '" class="gallery-list-item rotaryfocus" data-size="' . $imageinfo[0] . 'x' . $imageinfo[1] . '"';
-                echo ' data-pswp-width="' . $imageinfo[0] . '" data-pswp-height="' . $imageinfo[1] . '"';
-                echo ' data-med="' . PathUtility::getPublicPath($filename_thumb) . '" data-med-size="' . $imageinfoThumb[0] . 'x' . $imageinfoThumb[1] . '">';
+                echo '<a href="' . PathUtility::getPublicPath($filename_photo) . '" class="gallery-list-item rotaryfocus" data-size="' . $imageinfo['width'] . 'x' . $imageinfo['height'] . '"';
+                echo ' data-pswp-width="' . $imageinfo['width'] . '" data-pswp-height="' . $imageinfo['height'] . '"';
+                echo ' data-med="' . PathUtility::getPublicPath($filename_thumb) . '" data-med-size="' . $imageinfoThumb['width'] . 'x' . $imageinfoThumb['height'] . '">';
                 echo '<figure>';
                 echo '<img src="' . PathUtility::getPublicPath($filename_thumb) . '" alt="' . $image . '" loading="lazy"';
-                if ($imageinfo[1] > $imageinfo[0]) {
+                if ($imageinfo['height'] > $imageinfo['width']) {
                     echo 'style="padding-left: 25%;padding-right: 25%;"';
                 }
                 echo ' />';


### PR DESCRIPTION
  - Add ImageMetadataCacheService to persist image width/height metadata in data/image_metadata_cache.json.
  - Use the cache in template/components/gallery.images.php for photos and thumbnails, falling back to getimagesize on cache miss.
  - Preserve existing gallery behavior while reducing filesystem calls on repeated gallery renders

<!--
    Thank you for contributing!
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/PhotoboothProject/photobooth/blob/dev/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "x" next to an item)
<!-- Example:
- [x] Bug fix
-->

- [ ] Documentation update
- [ ] Bug fix
- [x] New feature
- [ ] Other, please explain:

<!--
    Please ensure your pull request is ready:

    - Please run 'npm run build' before submitting to have consistent formatting for both JavaScript & SCSS
    - Please run 'npm run eslint' to make sure there's no lint issues
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)
Gallery reads image size form every file verytime, this will cache it

#### Is there anything you'd like reviewers to focus on?
