### PR TITLE
fix black image after applying frame with initial config rotation 0

### DIFF
--- a/api/applyEffects.php
+++ b/api/applyEffects.php
@@ -150,10 +150,10 @@ try {
                     }
                 }
 
-                if ($config['picture']['rotation'] !== '0') {
+                if ((int)$config['picture']['rotation'] !== 0) {
                     $imageResource = $imageHandler->rotateResizeImage(
                         image: $imageResource,
-                        degrees: $config['picture']['rotation']
+                        degrees: (int)$config['picture']['rotation'],
                     );
                     if (!$imageResource instanceof \GdImage) {
                         throw new \Exception('Error resizing resource.');
@@ -161,7 +161,7 @@ try {
                 }
 
                 // Apply rembg
-                list($imageHandler, $imageResource) = Rembg::process($imageHandler, $vars, $config['rembg'], $imageResource);
+                [$imageHandler, $imageResource] = Rembg::process($imageHandler, $vars, $config['rembg'], $imageResource);
                 if ($config['picture']['polaroid_effect']) {
                     $imageHandler->polaroidRotation = $config['picture']['polaroid_rotation'];
                     $imageResource = $imageHandler->effectPolaroid($imageResource);

--- a/api/chromakeying/save.php
+++ b/api/chromakeying/save.php
@@ -121,10 +121,10 @@ try {
             }
         }
 
-        if ($config['picture']['rotation'] !== '0') {
+        if ((int)$config['picture']['rotation'] !== 0) {
             $imageResource = $imageHandler->rotateResizeImage(
                 image: $imageResource,
-                degrees: $config['picture']['rotation']
+                degrees: (int)$config['picture']['rotation'],
             );
             if (!$imageResource instanceof \GdImage) {
                 throw new \Exception('Error resizing resource.');

--- a/src/Image.php
+++ b/src/Image.php
@@ -438,6 +438,11 @@ class Image
      */
     public function rotateResizeImage(GdImage $image, int $degrees, string $bgColor = '#ffffff', bool $useTransparentBackground = false): GdImage|false
     {
+        if ($degrees % 360 === 0) {
+            // No rotation needed for 0, 360, -360, etc.
+            return $image;
+        }
+
         $new = $image;
         try {
             // simple rotate if possible and ignore changed dimensions (doesn't need to care about background color)
@@ -447,6 +452,8 @@ class Image
                 if (!$new) {
                     throw new \Exception('Cannot rotate image.');
                 }
+                // without, 0 degree rotation would loose alpha blending, results in black image
+                imagealphablending($new, true);
             } else {
                 $old_width = imagesx($image);
                 $old_height = imagesy($image);
@@ -465,7 +472,7 @@ class Image
                     $background = imagecolorallocatealpha($new, 0, 0, 0, 127);
                 } else {
                     $colorComponents = self::getColorComponents($bgColor);
-                    list($bg_r, $bg_g, $bg_b, $bg_a) = $colorComponents;
+                    [$bg_r, $bg_g, $bg_b, $bg_a] = $colorComponents;
                     // color background as defined
                     $background = imagecolorallocatealpha($new, $bg_r, $bg_g, $bg_b, $bg_a);
                 }

--- a/test/photo.php
+++ b/test/photo.php
@@ -42,9 +42,9 @@ try {
     }
     if (class_exists('Photobooth\Processor\ImageProcessor')) {
         $processor = new ImageProcessor($imageHandler, $logger, $database, $vars, $config);
-    }
-    if ($processor !== null && $processor instanceof ImageProcessor && method_exists($processor, 'preImageProcessing')) {
-        [$imageHandler, $vars, $config, $imageResource] = $processor->preImageProcessing($imageHandler, $vars, $config, $imageResource);
+        if (method_exists($processor, 'preImageProcessing')) {
+            [$imageHandler, $vars, $config, $imageResource] = $processor->preImageProcessing($imageHandler, $vars, $config, $imageResource);
+        }
     }
     $imageHandler->framePath = PathUtility::getPublicPath($config['picture']['frame']);
 
@@ -73,10 +73,10 @@ try {
         }
     }
 
-    if ($config['picture']['rotation'] !== '0') {
+    if ((int)$config['picture']['rotation'] !== 0) {
         $imageResource = $imageHandler->rotateResizeImage(
             image: $imageResource,
-            degrees: $config['picture']['rotation']
+            degrees: (int)$config['picture']['rotation'],
         );
         if (!$imageResource) {
             throw new \Exception('Error resizing resource.');


### PR DESCRIPTION
…loose alpha blending, resulting in black image.

<!--
    Thank you for contributing!
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/PhotoboothProject/photobooth/blob/dev/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "x" next to an item)
<!-- Example:
- [x] Bug fix
-->

- [ ] Documentation update
- [x] Bug fix
- [ ] New feature
- [ ] Other, please explain:

<!--
    Please ensure your pull request is ready:

    - Please run 'npm run build' before submitting to have consistent formatting for both JavaScript & SCSS
    - Please run 'npm run eslint' to make sure there's no lint issues
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)
initial config would rotate by 0 degree, resulting in a black image when adding the frame cause of alpha loss.
this fixes the conditions

#### Is there anything you'd like reviewers to focus on?
