### PR TITLE
fix(test photo): Use custom demo images for photo test

### DIFF
--- a/test/photo.php
+++ b/test/photo.php
@@ -36,7 +36,7 @@ try {
     $imageHandler->debugLevel = $config['dev']['loglevel'];
     $imageHandler->imageModified = false;
 
-    $imageResource = $imageHandler->createFromImage(ImageUtility::getRandomImageFromPath('resources/img/demo'));
+    $imageResource = $imageHandler->createFromImage(ImageUtility::getDemoImages(1)[0]);
     if (!$imageResource) {
         throw new \Exception('Error creating image resource.');
     }


### PR DESCRIPTION
Previously, the single photo test in the admin panel always used predefined images from 'resources/img/demo', ignoring custom demo images placed in 'private/images/demo'.

This commit updates 'admin/a_phototest.php' to utilize 'ImageUtility::getDemoImages(1)[0]' which correctly prioritizes custom demo images.

<!--
    Thank you for contributing!
-->

#### Prerequisites checklist
- [x] I have read the [contributing guidelines](https://github.com/PhotoboothProject/photobooth/blob/dev/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "x" next to an item)
- [ ] Documentation update
- [x] Bug fix
- [ ] New feature
- [ ] Other, please explain:


#### What changes did you make? (Give an overview)
Updated 'admin/a_phototest.php' to correctly load custom demo images from 'private/images/demo' by utilizing 'ImageUtility::getDemoImages(1)[0]'. This ensures that user-provided test images are prioritized over the default ones for the single photo test.

#### Is there anything you'd like reviewers to focus on?
The change primarily affects 'admin/a_phototest.php' and leverages existing utility logic. Please verify if the prioritization of demo image folders (private/images/demo -> data/tmp -> resources/img/demo) is correctly applied and if the single image selection logic behaves as expected.