### PR TITLE
Fix typo in install script

### DIFF
--- a/install-photobooth.sh
+++ b/install-photobooth.sh
@@ -2892,7 +2892,7 @@ function install_or_update_photobooth() {
                 setup_apache=true
                 ;;
             2)
-                comfirm "Webserver" "Nginx is installed and running. Please configure your Webserver manually if needed."
+                confirm "Webserver" "Nginx is installed and running. Please configure your Webserver manually if needed."
                 setup_apache=false
                 ;;
             3)


### PR DESCRIPTION
Nothing serious, there is just a typo in the install script where it says "comfirm" instead of "confirm".

Have a nice day.

PS: Ironically, I made a typo in the commit message saying "type" instead of "typo".