### PR TITLE
Feature/theme import export, admin config cards dirty highlight and revert btn

### DIFF
--- a/admin/components/_getSettings.php
+++ b/admin/components/_getSettings.php
@@ -38,7 +38,7 @@ foreach ($configsetup as $section => $fields) {
         $i18ntag = $section . ':' . $key;
 
         echo '<!-- ' . strtoupper($setting['type']) . ' ' . strtoupper($setting['name']) . ' -->';
-        echo '<div class="flex flex-col rounded-xl p-3 shadow-xl bg-white ' . $hidden . '" id="' . $i18ntag . '">';
+        echo '<div class="adminSettingCard relative flex flex-col rounded-xl p-3 shadow-xl bg-white ' . $hidden . '" id="' . $i18ntag . '">';
 
         $isThemeField = ($setting['data-theme-field'] ?? '') === 'true' || ($setting['data-theme-field'] ?? false) === true;
         AdminInput::setThemeFieldFlag($isThemeField);

--- a/api/themes.php
+++ b/api/themes.php
@@ -4,9 +4,13 @@ require_once '../lib/boot.php';
 
 use Photobooth\Service\ThemeService;
 
-header('Content-Type: application/json');
-
 $themeService = ThemeService::getInstance();
+
+$sendJson = static function (array $payload): void {
+    header('Content-Type: application/json');
+    echo json_encode($payload);
+    exit();
+};
 
 $method = $_SERVER['REQUEST_METHOD'] ?? 'GET';
 $query = $_GET;
@@ -16,36 +20,80 @@ if ($method === 'GET') {
 
     if ($action === 'list') {
         $all = $themeService->getAll();
-        echo json_encode([
+        $sendJson([
             'status' => 'success',
             'themes' => array_keys($all),
         ]);
-        exit();
     }
 
     if ($action === 'get') {
         $name = (string)($query['name'] ?? '');
         $theme = $themeService->get($name);
         if ($theme === null) {
-            echo json_encode([
+            $sendJson([
                 'status' => 'error',
                 'message' => 'Theme not found',
             ]);
-            exit();
         }
 
-        echo json_encode([
+        $sendJson([
             'status' => 'success',
             'theme' => $theme,
         ]);
+    }
+
+    if ($action === 'export') {
+        $name = (string)($query['name'] ?? '');
+        $result = $themeService->exportTheme($name);
+        if (!$result['success'] || !isset($result['file'])) {
+            $sendJson([
+                'status' => 'error',
+                'message' => $result['message'] ?? 'Failed to export theme',
+            ]);
+        }
+
+        $downloadName = isset($result['downloadName']) ? basename($result['downloadName']) : 'theme.zip';
+        $filePath = $result['file'];
+        header('Content-Type: application/zip');
+        header('Content-Disposition: attachment; filename="' . $downloadName . '"');
+        header('Content-Length: ' . filesize($filePath));
+        readfile($filePath);
+        @unlink($filePath);
         exit();
     }
 
-    echo json_encode([
+    $sendJson([
         'status' => 'error',
         'message' => 'Unknown action',
     ]);
-    exit();
+}
+
+// Handle multipart/form-data import first
+$postAction = $_POST['action'] ?? null;
+if ($postAction === 'import') {
+    if (!isset($_FILES['theme_zip']) || !is_uploaded_file($_FILES['theme_zip']['tmp_name']) || $_FILES['theme_zip']['error'] !== UPLOAD_ERR_OK) {
+        $sendJson([
+            'status' => 'error',
+            'message' => 'No theme zip provided',
+        ]);
+    }
+
+    $targetName = isset($_POST['name']) ? (string)$_POST['name'] : null;
+    $tmpFile = $_FILES['theme_zip']['tmp_name'];
+
+    $result = $themeService->importTheme($tmpFile, $targetName);
+    if (!$result['success']) {
+        $sendJson([
+            'status' => 'error',
+            'message' => $result['message'] ?? 'Import failed',
+        ]);
+    }
+
+    $sendJson([
+        'status' => 'success',
+        'name' => $result['name'] ?? '',
+        'theme' => $result['theme'] ?? [],
+    ]);
 }
 
 $rawBody = file_get_contents('php://input');
@@ -62,44 +110,39 @@ if ($action === 'save') {
     $data = isset($body['theme']) && is_array($body['theme']) ? $body['theme'] : [];
 
     if ($name === '') {
-        echo json_encode([
+        $sendJson([
             'status' => 'error',
             'message' => 'Missing theme name',
         ]);
-        exit();
     }
 
     $themeService->save($name, $data);
 
-    echo json_encode([
+    $sendJson([
         'status' => 'success',
         'message' => 'Theme saved',
     ]);
-    exit();
 }
 
 if ($action === 'delete') {
     $name = isset($body['name']) ? (string)$body['name'] : '';
 
     if ($name === '') {
-        echo json_encode([
+        $sendJson([
             'status' => 'error',
             'message' => 'Missing theme name',
         ]);
-        exit();
     }
 
     $themeService->delete($name);
 
-    echo json_encode([
+    $sendJson([
         'status' => 'success',
         'message' => 'Theme deleted',
     ]);
-    exit();
 }
 
-echo json_encode([
+$sendJson([
     'status' => 'error',
     'message' => 'Unknown action',
 ]);
-exit();

--- a/assets/js/admin/index.js
+++ b/assets/js/admin/index.js
@@ -1,5 +1,7 @@
 /* globals photoboothTools */
 $(function () {
+    initDirtyTracking();
+
     // adminRangeInput
     $(document).on('input', '.adminRangeInput', function () {
         document.querySelector('#' + this.name.replace('[', '\\[').replace(']', '\\]') + '-value span').innerHTML =
@@ -36,3 +38,109 @@ const shellCommand = function ($mode, $filename = '') {
             photoboothTools.console.log($mode, 'result: ', result);
         });
 };
+
+function initDirtyTracking() {
+    const $fields = $('.adminSection').find('input, select, textarea').not('[type="hidden"]');
+
+    $fields.each(function () {
+        const $el = $(this);
+        $el.data('initial', readFieldValue($el));
+    });
+
+    $(document).on('change input', '.adminSection input, .adminSection select, .adminSection textarea', function () {
+        updateDirtyState($(this));
+    });
+
+    $(document).on('click', '.adminSettingCard-revert', function (e) {
+        e.preventDefault();
+        const $card = $(this).closest('.adminSettingCard');
+        revertCard($card);
+    });
+}
+
+function readFieldValue($el) {
+    const el = $el[0];
+    if (el.tagName === 'SELECT' && el.multiple) {
+        return ($el.val() || []).slice().sort().join('|');
+    }
+    if (el.type === 'checkbox') {
+        return $el.is(':checked') ? '1' : '0';
+    }
+    return $el.val();
+}
+
+function updateDirtyState($el) {
+    const initial = $el.data('initial');
+    const current = readFieldValue($el);
+    const isDirty = initial !== current;
+    const $card = $el.closest('.adminSettingCard');
+
+    if ($card.length === 0) {
+        return;
+    }
+
+    if (isDirty) {
+        $card.addClass('ring-2 ring-indigo-200 shadow-indigo-200');
+        $el.data('dirty', true);
+        ensureRevertButton($card);
+    } else {
+        $el.data('dirty', false);
+        if (
+            !$card.find('input,select,textarea').filter(function () {
+                return $(this).data('dirty');
+            }).length
+        ) {
+            $card.removeClass('ring-2 ring-indigo-200 shadow-indigo-200');
+            removeRevertButton($card);
+        }
+    }
+}
+
+function ensureRevertButton($card) {
+    if ($card.find('.adminSettingCard-revert').length) {
+        return;
+    }
+    const btn = $(
+        '<button type="button" class="adminSettingCard-revert h-7 w-7 absolute right-2 top-2 text-xs font-semibold text-amber-700 border border-amber-400 rounded-full bg-amber-50 hover:bg-amber-100" title="Revert">' +
+            '<i class="fa fa-undo"></i>' +
+            '</button>'
+    );
+    $card.append(btn);
+}
+
+function removeRevertButton($card) {
+    $card.find('.adminSettingCard-revert').remove();
+}
+
+function revertCard($card) {
+    $card.find('input,select,textarea').each(function () {
+        const $el = $(this);
+        const initial = $el.data('initial');
+        restoreFieldValue($el, initial);
+        $el.data('dirty', false);
+    });
+    $card.removeClass('ring-2 ring-indigo-400 shadow-indigo-200');
+    removeRevertButton($card);
+}
+
+function restoreFieldValue($el, value) {
+    const el = $el[0];
+    if (el.tagName === 'SELECT' && el.multiple) {
+        const list = (value || '').split('|').filter((v) => v !== '');
+        $el.val(list);
+    } else if (el.type === 'checkbox') {
+        $el.prop('checked', value === '1');
+    } else {
+        $el.val(value);
+    }
+    $el.trigger('change');
+
+    // Keep range labels in sync after revert
+    if ($el.hasClass('adminRangeInput')) {
+        const labelId = '#' + el.name.replace('[', '\\[').replace(']', '\\]') + '-value span';
+        const labelEl = document.querySelector(labelId);
+        if (labelEl) {
+            labelEl.innerHTML = $el.val();
+        }
+    }
+}

--- a/assets/js/admin/themes.js
+++ b/assets/js/admin/themes.js
@@ -8,6 +8,9 @@ $(function () {
         const $saveButton = $('#theme-save-btn');
         const $loadButton = $('#theme-load-btn');
         const $deleteButton = $('#theme-delete-btn');
+        const $exportButton = $('#theme-export-btn');
+        const $importButton = $('#theme-import-btn');
+        const $importInput = $('#theme-import-input');
         const $select = $('#theme-select');
         const $currentInput = $('input[name="theme[current]"]');
         let lastAppliedThemeSnapshot = null;
@@ -25,7 +28,7 @@ $(function () {
         }
 
         function updateLoadButtonState() {
-            if ($loadButton.length === 0 || $deleteButton.length === 0) {
+            if ($loadButton.length === 0 || $deleteButton.length === 0 || $exportButton.length === 0) {
                 return;
             }
 
@@ -49,14 +52,15 @@ $(function () {
                 $loadButton.removeClass('opacity-40 cursor-not-allowed');
             }
 
-            // Disable delete button when no theme is selected
-            if (!selected) {
-                $deleteButton.prop('disabled', true);
-                $deleteButton.addClass('opacity-40 cursor-not-allowed');
-            } else {
-                $deleteButton.prop('disabled', false);
-                $deleteButton.removeClass('opacity-40 cursor-not-allowed');
-            }
+            const disabledClasses = 'opacity-40 cursor-not-allowed';
+
+            const toggleButton = (button, isDisabled) => {
+                button.prop('disabled', isDisabled);
+                button.toggleClass(disabledClasses, isDisabled);
+            };
+
+            toggleButton($deleteButton, !selected);
+            toggleButton($exportButton, !selected);
         }
 
         function getThemeElements() {
@@ -203,9 +207,10 @@ $(function () {
             });
         }
 
-        function refreshSelect() {
+        function refreshSelect(desiredSelection = null) {
             const current = $currentInput.length ? $currentInput.val() : '';
             const previousSelected = $select.val();
+            const targetSelection = desiredSelection ?? previousSelected;
 
             $.getJSON(apiBase, { action: 'list', _: Date.now() })
                 .done((data) => {
@@ -224,12 +229,16 @@ $(function () {
                             $('<option>', {
                                 value: key,
                                 text: key,
-                                selected: key === previousSelected
+                                selected: key === previousSelected || key === targetSelection
                             }).appendTo($select);
                         });
 
                     if (current && $nameInput.length) {
                         $nameInput.val(current);
+                    }
+
+                    if (targetSelection) {
+                        $select.val(targetSelection);
                     }
 
                     updateLoadButtonState();
@@ -350,6 +359,80 @@ $(function () {
                 })
                 .fail(() => {
                     photoboothTools.overlay.showError(photoboothTools.getTranslation('error'));
+                });
+        });
+
+        $exportButton.on('click', () => {
+            const selected = $select.val();
+            if (!selected) {
+                return;
+            }
+
+            const url = `${apiBase}?action=export&name=${encodeURIComponent(selected)}&_=${Date.now()}`;
+            const link = document.createElement('a');
+            link.href = url;
+            link.download = `${selected}.zip`;
+            document.body.appendChild(link);
+            link.click();
+            document.body.removeChild(link);
+        });
+
+        $importButton.on('click', () => {
+            if ($importInput.length) {
+                $importInput.trigger('click');
+            }
+        });
+
+        $importInput.on('change', function onImportChange() {
+            const file = this.files ? this.files[0] : null;
+            if (!file) {
+                return;
+            }
+
+            const formData = new FormData();
+            formData.append('action', 'import');
+            formData.append('theme_zip', file);
+
+            const desiredName = $nameInput.length ? $nameInput.val().trim() : '';
+            if (desiredName) {
+                formData.append('name', desiredName);
+            }
+
+            $.ajax({
+                url: apiBase,
+                method: 'POST',
+                data: formData,
+                processData: false,
+                contentType: false,
+                dataType: 'json'
+            })
+                .done((data) => {
+                    if (data.status !== 'success') {
+                        photoboothTools.overlay.showError(photoboothTools.getTranslation('error'));
+                        return;
+                    }
+
+                    const importedName = data.name || desiredName;
+                    if (data.theme) {
+                        applyTheme(data.theme);
+                        snapshotTheme();
+                    }
+
+                    if ($currentInput.length && importedName) {
+                        $currentInput.val(importedName);
+                    }
+                    if ($nameInput.length && importedName) {
+                        $nameInput.val(importedName);
+                    }
+
+                    refreshSelect(importedName);
+                    updateLoadButtonState();
+                })
+                .fail(() => {
+                    photoboothTools.overlay.showError(photoboothTools.getTranslation('error'));
+                })
+                .always(() => {
+                    $importInput.val('');
                 });
         });
         refreshSelect();

--- a/docs/customizing/themes.md
+++ b/docs/customizing/themes.md
@@ -62,6 +62,21 @@ In the **Themes** card you can:
     - Click **Save theme**.
     - A JSON file is created or updated in `private/themes`.
 
+- **Export** a theme
+    - Select a theme from the dropdown.
+    - Click **Export**.
+    - A ZIP is downloaded containing:
+        - `private/themes/<theme-name>.theme.config.json`
+        - All files referenced by the theme (for example background images, frames, logos) from `private/` and `resources/`.
+        - The folder structure inside the ZIP preserves the paths relative to the project root.
+
+- **Import** a theme
+    - Click **Import** and choose a ZIP created by the export feature.
+    - The theme name is taken from the `.theme.config.json` filename inside the ZIP.
+    - If a theme with the same name already exists, it is overwritten.
+    - The ZIP is unpacked into the project preserving its contained folder structure (only `private/` and `resources/` are written).
+    - The imported theme shows up in the dropdown and will be applied immediately.
+
 - **Load** a theme
     - Select a theme from the dropdown.
     - Click **Load theme**.

--- a/docs/customizing/themes.md
+++ b/docs/customizing/themes.md
@@ -30,7 +30,7 @@ Themes are stored as JSON files in `private/themes`.
   "event": {
     "symbol": "fa-birthday-cake",
     "textLeft": "Lisa & Tom",
-    "textRight": "01.01.2026"
+    "textRight": "01.01."
   },
   "colors": {
     "primary": "#4a7c1f",
@@ -39,7 +39,7 @@ Themes are stored as JSON files in `private/themes`.
     "countdown": "#5b7d4a"
   },
   "picture": {
-    "frame": "/private/images/frames/birthday.png",
+    "frame": "private/images/frames/birthday.png",
     "extend_by_frame": "false"
   },
   "collage": {

--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -937,6 +937,7 @@
   "theme_choose": "Choose theme",
   "theme_override_confirm": "Saving will override theme \"%s\". Continue?",
   "theme_unsaved_confirm": "You have unsaved theme changes. Loading will discard them. Continue?",
+  "manual:theme_title": "Use the Themes box to save current theme fields, load another, export a ZIP (config + referenced images), or import that ZIP to install a theme. Import or save will overwrite an existing theme with the same name.",
   "text_settings": "Text settings",
   "toggleFullscreen": "Toggle Fullscreen",
   "translate": "Translate",

--- a/src/Service/ThemeService.php
+++ b/src/Service/ThemeService.php
@@ -154,7 +154,14 @@ class ThemeService
 
         // add theme config file at its project-relative location
         $themeRelativePath = 'private/themes/' . $safeName . '.theme.config.json';
-        $zip->addFromString($themeRelativePath, json_encode($theme, JSON_PRETTY_PRINT));
+        $themeJson = json_encode($theme, JSON_PRETTY_PRINT);
+        if ($themeJson === false) {
+            return [
+                'success' => false,
+                'message' => 'Unable to encode theme',
+            ];
+        }
+        $zip->addFromString($themeRelativePath, $themeJson);
 
         // add referenced assets using their project-relative paths
         $assets = $this->collectAssetCandidates($theme);
@@ -202,9 +209,10 @@ class ThemeService
         $themeFilename = null;
         for ($i = 0; $i < $zip->numFiles; $i++) {
             $stat = $zip->statIndex($i);
-            if (!$stat || !isset($stat['name'])) {
+            if (!is_array($stat)) {
                 continue;
             }
+            /** @var array{name:string} $stat */
             $nameInZip = $stat['name'];
             if (str_ends_with($nameInZip, '.theme.config.json')) {
                 $themeFileIndex = $i;
@@ -247,10 +255,10 @@ class ThemeService
         $root = PathUtility::getRootPath();
         for ($i = 0; $i < $zip->numFiles; $i++) {
             $stat = $zip->statIndex($i);
-            if (!$stat || !isset($stat['name'])) {
+            if (!is_array($stat)) {
                 continue;
             }
-
+            /** @var array{name:string} $stat */
             $entryName = $stat['name'];
             // Normalize
             $entryName = PathUtility::fixFilePath($entryName);
@@ -320,6 +328,9 @@ class ThemeService
     private function getSafeName(string $name): string
     {
         $safeName = preg_replace('/[^a-zA-Z0-9_\-]/', '_', $name);
+        if ($safeName === null) {
+            $safeName = '';
+        }
         if ($safeName === '') {
             $safeName = 'theme';
         }

--- a/src/Service/ThemeService.php
+++ b/src/Service/ThemeService.php
@@ -251,7 +251,7 @@ class ThemeService
         $safeName = $this->getSafeName($themeName);
 
         // extract allowed files preserving structure
-        $allowedPrefixes = ['private/', 'resources/'];
+        $allowedPrefixes = ['private/'];
         $root = PathUtility::getRootPath();
         for ($i = 0; $i < $zip->numFiles; $i++) {
             $stat = $zip->statIndex($i);
@@ -373,10 +373,17 @@ class ThemeService
                 }
             }
 
+            $projectRelative = PathUtility::toProjectRelative($absolute);
+
+            // Skip generated assets living in resources/ per export policy
+            if (str_starts_with($projectRelative, 'resources/')) {
+                return;
+            }
+
             $results[] = [
                 'original' => $value,
                 'absolute' => $absolute,
-                'relative' => PathUtility::toProjectRelative($absolute),
+                'relative' => $projectRelative,
             ];
         });
 

--- a/src/Service/ThemeService.php
+++ b/src/Service/ThemeService.php
@@ -3,10 +3,13 @@
 namespace Photobooth\Service;
 
 use Photobooth\Utility\PathUtility;
+use ZipArchive;
 
 class ThemeService
 {
     private string $themeDirectory;
+    /** @var string[] */
+    private array $imageExtensions = ['png', 'jpg', 'jpeg', 'gif', 'webp', 'svg', 'avif', 'heic', 'bmp'];
 
     public function __construct()
     {
@@ -115,15 +118,312 @@ class ThemeService
         if (is_file($file)) {
             @unlink($file);
         }
+
+        $this->removeAssetsDirectory($name);
+    }
+
+    /**
+     * @return array{success:bool,message?:string,file?:string,downloadName?:string}
+     */
+    public function exportTheme(string $name): array
+    {
+        $theme = $this->get($name);
+        if ($theme === null) {
+            return [
+                'success' => false,
+                'message' => 'Theme not found',
+            ];
+        }
+
+        $safeName = $this->getSafeName($name);
+        $tempZip = tempnam(sys_get_temp_dir(), 'theme_export_');
+        if ($tempZip === false) {
+            return [
+                'success' => false,
+                'message' => 'Unable to create temporary file',
+            ];
+        }
+
+        $zip = new ZipArchive();
+        if ($zip->open($tempZip, ZipArchive::CREATE | ZipArchive::OVERWRITE) !== true) {
+            return [
+                'success' => false,
+                'message' => 'Unable to open archive',
+            ];
+        }
+
+        // add theme config file at its project-relative location
+        $themeRelativePath = 'private/themes/' . $safeName . '.theme.config.json';
+        $zip->addFromString($themeRelativePath, json_encode($theme, JSON_PRETTY_PRINT));
+
+        // add referenced assets using their project-relative paths
+        $assets = $this->collectAssetCandidates($theme);
+        foreach ($assets as $asset) {
+            $absolutePath = $asset['absolute'];
+            $relativePath = $asset['relative'];
+
+            if (!is_readable($absolutePath)) {
+                continue;
+            }
+
+            $zip->addFile($absolutePath, $relativePath);
+        }
+
+        $zip->close();
+
+        $downloadName = sprintf(
+            'photobooth_theme_%s_%s.zip',
+            $safeName,
+            date('Ymd_His')
+        );
+
+        return [
+            'success' => true,
+            'file' => $tempZip,
+            'downloadName' => $downloadName,
+        ];
+    }
+
+    /**
+     * @return array{success:bool,message?:string,name?:string,theme?:array<string,mixed>}
+     */
+    public function importTheme(string $zipPath, ?string $targetName = null): array
+    {
+        $zip = new ZipArchive();
+        if ($zip->open($zipPath) !== true) {
+            return [
+                'success' => false,
+                'message' => 'Could not open archive',
+            ];
+        }
+
+        // Find theme config in zip
+        $themeFileIndex = null;
+        $themeFilename = null;
+        for ($i = 0; $i < $zip->numFiles; $i++) {
+            $stat = $zip->statIndex($i);
+            if (!$stat || !isset($stat['name'])) {
+                continue;
+            }
+            $nameInZip = $stat['name'];
+            if (str_ends_with($nameInZip, '.theme.config.json')) {
+                $themeFileIndex = $i;
+                $themeFilename = $nameInZip;
+                break;
+            }
+        }
+
+        if ($themeFileIndex === null || $themeFilename === null) {
+            $zip->close();
+            return [
+                'success' => false,
+                'message' => 'Archive does not contain a theme config',
+            ];
+        }
+
+        $themeContent = $zip->getFromIndex($themeFileIndex);
+        if ($themeContent === false) {
+            $zip->close();
+            return [
+                'success' => false,
+                'message' => 'Unable to read theme config',
+            ];
+        }
+
+        $themeData = json_decode($themeContent, true);
+        if (!is_array($themeData)) {
+            $zip->close();
+            return [
+                'success' => false,
+                'message' => 'Invalid theme config JSON',
+            ];
+        }
+
+        $themeName = basename($themeFilename, '.theme.config.json');
+        $safeName = $this->getSafeName($themeName);
+
+        // extract allowed files preserving structure
+        $allowedPrefixes = ['private/', 'resources/'];
+        $root = PathUtility::getRootPath();
+        for ($i = 0; $i < $zip->numFiles; $i++) {
+            $stat = $zip->statIndex($i);
+            if (!$stat || !isset($stat['name'])) {
+                continue;
+            }
+
+            $entryName = $stat['name'];
+            // Normalize
+            $entryName = PathUtility::fixFilePath($entryName);
+
+            $isAllowed = false;
+            foreach ($allowedPrefixes as $prefix) {
+                if (str_starts_with($entryName, $prefix)) {
+                    $isAllowed = true;
+                    break;
+                }
+            }
+
+            if (!$isAllowed) {
+                continue;
+            }
+
+            $targetPath = $root . ltrim($entryName, '/');
+            $targetPath = PathUtility::fixFilePath($targetPath);
+
+            // guard against directory traversal
+            if (!str_starts_with($targetPath, $root)) {
+                continue;
+            }
+
+            if (str_ends_with($entryName, '/')) {
+                if (!is_dir($targetPath)) {
+                    @mkdir($targetPath, 0775, true);
+                }
+                continue;
+            }
+
+            $dir = dirname($targetPath);
+            if (!is_dir($dir)) {
+                @mkdir($dir, 0775, true);
+            }
+
+            $stream = $zip->getStream($stat['name']);
+            if ($stream === false) {
+                continue;
+            }
+            $content = stream_get_contents($stream);
+            fclose($stream);
+            if ($content === false) {
+                continue;
+            }
+            @file_put_contents($targetPath, $content);
+        }
+
+        $this->save($safeName, $themeData);
+
+        $zip->close();
+
+        return [
+            'success' => true,
+            'name' => $safeName,
+            'theme' => $themeData,
+        ];
     }
 
     private function getFilePath(string $name): string
+    {
+        $safeName = $this->getSafeName($name);
+
+        return $this->themeDirectory . DIRECTORY_SEPARATOR . $safeName . '.theme.config.json';
+    }
+
+    private function getSafeName(string $name): string
     {
         $safeName = preg_replace('/[^a-zA-Z0-9_\-]/', '_', $name);
         if ($safeName === '') {
             $safeName = 'theme';
         }
 
-        return $this->themeDirectory . DIRECTORY_SEPARATOR . $safeName . '.theme.config.json';
+        return $safeName;
+    }
+
+    /**
+     * @param array<string,mixed> $theme
+     * @return array<int,array{original:string,absolute:string,relative:string}>
+     */
+    private function collectAssetCandidates(array $theme): array
+    {
+        $results = [];
+        $this->walkThemeValues($theme, function (string $value) use (&$results) {
+            $trimmed = trim($value);
+            $pathPart = explode('?', $trimmed)[0];
+            $extension = strtolower(pathinfo($pathPart, PATHINFO_EXTENSION));
+            if ($extension === '' || !in_array($extension, $this->imageExtensions, true)) {
+                return;
+            }
+
+            if (PathUtility::isUrl($pathPart)) {
+                return;
+            }
+
+            try {
+                $absolute = PathUtility::resolveFilePath($pathPart);
+                $rootPath = PathUtility::getRootPath();
+                if (!is_readable($absolute) || !str_starts_with($absolute, $rootPath)) {
+                    return;
+                }
+            } catch (\Throwable) {
+                return;
+            }
+
+            foreach ($results as $existing) {
+                if ($existing['original'] === $value) {
+                    return;
+                }
+            }
+
+            $results[] = [
+                'original' => $value,
+                'absolute' => $absolute,
+                'relative' => PathUtility::toProjectRelative($absolute),
+            ];
+        });
+
+        return $results;
+    }
+
+    private function getAssetsDirectory(string $name): string
+    {
+        $safeName = $this->getSafeName($name);
+
+        return $this->themeDirectory . DIRECTORY_SEPARATOR . $safeName . DIRECTORY_SEPARATOR . 'assets';
+    }
+
+    private function removeAssetsDirectory(string $name): void
+    {
+        $assetsDir = $this->getAssetsDirectory($name);
+        if (!is_dir($assetsDir)) {
+            return;
+        }
+
+        $files = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($assetsDir, \FilesystemIterator::SKIP_DOTS),
+            \RecursiveIteratorIterator::CHILD_FIRST
+        );
+
+        foreach ($files as $fileinfo) {
+            if ($fileinfo->isDir()) {
+                @rmdir($fileinfo->getRealPath());
+            } else {
+                @unlink($fileinfo->getRealPath());
+            }
+        }
+
+        @rmdir($assetsDir);
+        $themeDir = dirname($assetsDir);
+        $children = glob($themeDir . DIRECTORY_SEPARATOR . '*');
+        if (is_dir($themeDir) && ($children === false || count($children) === 0)) {
+            @rmdir($themeDir);
+        }
+    }
+
+    /**
+     * Walk nested theme array and call callback for each string value.
+     *
+     * @param array<string,mixed> $data
+     * @param callable(string):void $callback
+     */
+    private function walkThemeValues(array $data, callable $callback): void
+    {
+        foreach ($data as $value) {
+            if (is_array($value)) {
+                $this->walkThemeValues($value, $callback);
+                continue;
+            }
+
+            if (is_string($value)) {
+                $callback($value);
+            }
+        }
     }
 }

--- a/src/Utility/AdminInput.php
+++ b/src/Utility/AdminInput.php
@@ -648,20 +648,20 @@ class AdminInput
 
         $tooltipClass = '
             absolute z-20 hidden flex-col px-3 py-2 text-sm font-medium text-white bg-gray-900 rounded-lg shadow-lg
-            w-80 max-w-[calc(100vw-4rem)] left-0 top-full mt-2 break-words
+            w-80 max-w-[calc(100vw-4rem)] left-0 top-full break-words
             peer-hover:flex peer-focus:flex
         ';
 
         $isThemeField = self::$themeField;
 
         return '
-            <div class="tooltip mb-3 relative flex items-center justify-between gap-2">
+            <div class="tooltip adminSettingCard-header mb-3 relative flex items-center justify-between gap-2 pr-10 min-h-[32px]">
                 <label class="peer text-black text-md font-bold inline-flex items-center gap-2 cursor-help">
                     <span>' . $languageService->translate($label) . '</span>
                 </label>
                 ' . ($isThemeField ? '<span class="text-[10px] font-semibold uppercase tracking-wide text-brand-1">Theme</span>' : '') . '
                 <span class="' . $tooltipClass . '">
-                    <div class="absolute left-4 -top-[10px] h-0 w-0 border-x-8 border-x-transparent border-b-[10px] border-gray-900"></div>
+                    <div class="absolute left-4 -top-[9px] h-0 w-0 border-x-8 border-x-transparent border-b-[10px] border-gray-900"></div>
                     ' . $languageService->translate('manual:' . $label) . '
                 </span>
             </div>

--- a/src/Utility/AdminInput.php
+++ b/src/Utility/AdminInput.php
@@ -508,12 +508,29 @@ class AdminInput
                     </div>
                     <div class="flex flex-row gap-2">
                         <button
+                            id="theme-export-btn"
+                            type="button"
+                            class="h-8 w-8 flex items-center justify-center rounded-full bg-content-1 text-brand-1 border border-solid border-brand-1 hover:bg-brand-1 hover:text-white transition text-[10px] font-bold"
+                            title="' . $languageService->translate('theme_export') . '"
+                        >
+                            <i class="fa fa-download"></i>
+                        </button>
+                        <button
+                            id="theme-import-btn"
+                            type="button"
+                            class="h-8 w-8 flex items-center justify-center rounded-full bg-content-1 text-brand-1 border border-solid border-brand-1 hover:bg-brand-1 hover:text-white transition text-[10px] font-bold"
+                            title="' . $languageService->translate('theme_import') . '"
+                        >
+                            <i class="fa fa-upload"></i>
+                        </button>
+                        <input id="theme-import-input" type="file" class="hidden" accept=".zip" />
+                        <button
                             id="theme-load-btn"
                             type="button"
                             class="h-8 w-8 flex items-center justify-center rounded-full bg-content-1 text-brand-1 border border-solid border-brand-1 hover:bg-brand-1 hover:text-white transition text-[10px] font-bold"
                             title="' . $languageService->translate('theme_load') . '"
                         >
-                            <i class="fa fa-download"></i>
+                            <i class="fa fa-refresh"></i>
                         </button>
                         <button
                             id="theme-delete-btn"

--- a/src/Utility/AdminInput.php
+++ b/src/Utility/AdminInput.php
@@ -661,7 +661,7 @@ class AdminInput
                 </label>
                 ' . ($isThemeField ? '<span class="text-[10px] font-semibold uppercase tracking-wide text-brand-1">Theme</span>' : '') . '
                 <span class="' . $tooltipClass . '">
-                    <div class="absolute left-4 -top-[9px] h-0 w-0 border-x-8 border-x-transparent border-b-[10px] border-gray-900"></div>
+                    <div class="absolute left-4 -top-[10px] h-0 w-0 border-x-8 border-x-transparent border-b-[10px] border-gray-900"></div>
                     ' . $languageService->translate('manual:' . $label) . '
                 </span>
             </div>

--- a/src/Utility/PathUtility.php
+++ b/src/Utility/PathUtility.php
@@ -172,6 +172,31 @@ class PathUtility
     }
 
     /**
+     * Converts a path to a project-relative, forward-slashed form.
+     *
+     * Behavior:
+     * - URLs are returned unchanged.
+     * - Absolute paths inside the project root are stripped to project-relative.
+     * - Absolute paths outside the project are returned as-is.
+     * - Relative paths are normalized (slashes fixed) and returned.
+     */
+    public static function toProjectRelative(string $path): string
+    {
+        if (self::isUrl($path)) {
+            return $path;
+        }
+
+        $normalized = self::fixFilePath($path);
+        $root = self::getRootPath();
+
+        if (self::isAbsolutePath($normalized) && str_starts_with($normalized, $root)) {
+            return self::fixFilePath(substr($normalized, strlen($root)));
+        }
+
+        return $normalized;
+    }
+
+    /**
      * Resolves a file path or URL to a readable absolute filesystem path.
      *
      * Resolution strategy:


### PR DESCRIPTION
 #### Prerequisites checklist

  - [x] I have read the contributing guidelines.

  #### What is the purpose of this pull request? (put an "x" next to an item)

  - [x] New feature
  - [x] Documentation update
  - [ ] Bug fix
  - [ ] Other, please explain:

  #### What changes did you make? (Give an overview)

  - Added full theme export/import flow: export creates photobooth_theme_<name>_<YYYYMMDD_HHMMSS>.zip containing private/themes/<name>.theme.config.json and all
    referenced assets in their original project paths; import reads the .theme.config.json name, writes allowed private/ and resources/ paths, and saves the theme.
  - Extended theme API endpoints and ThemeService for the above behavior
  - Admin UI updates: export/import buttons, per-card dirty highlighting with an inline revert icon.
  - Updated documentation for export/import behavior.

<img width="438" height="204" alt="grafik" src="https://github.com/user-attachments/assets/e04c25a6-c822-4a39-a0f8-27d4437304e7" />


<img width="1186" height="264" alt="grafik" src="https://github.com/user-attachments/assets/d6133ed0-e574-43cf-aea9-16d47ec24a99" />


  #### Is there anything you'd like reviewers to focus on?

  - Verify the export/import zip structure and overwrite behavior (import uses the .theme.config.json filename).
  - Check the admin UI dirty/revert interactions