### PR TITLE
fix: file-uploader validation

### DIFF
--- a/src/FileUploader.php
+++ b/src/FileUploader.php
@@ -140,7 +140,7 @@ class FileUploader
 
                 $this->logger->debug('Processing file', [$fileName]);
 
-                if ($this->validateFile($sanitizedFileName, $fileType, $filePath)) {
+                if ($this->validateFile($fileName, $fileType, $filePath)) {
                     $this->moveFile($fileTmpName, $filePath);
                     $uploadedFileNames[] = $sanitizedFileName;
                 }


### PR DESCRIPTION
The processFiles() function creates a sanitizedFileName, which is used to rename the uploaded file. The validateFile function should check the properties of the uploaded file. This function needs the original file name, not the sanitized version because the uploadedFiles array uses the original file names. If the sanitized version differs from the original one, there is an error and the file cannot be uploaded.

<!--
    Thank you for contributing!
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/PhotoboothProject/photobooth/blob/dev/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "x" next to an item)
<!-- Example:
- [x] Bug fix
-->

- [ ] Documentation update
- [x] Bug fix
- [ ] New feature
- [ ] Other, please explain:

<!--
    Please ensure your pull request is ready:

    - Please run 'npm run build' before submitting to have consistent formatting for both JavaScript & SCSS
    - Please run 'npm run eslint' to make sure there's no lint issues
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)
Fixes the file uploader, which currently fails if the uploaded file is renamed (sanitized file name)

#### Is there anything you'd like reviewers to focus on?
