### PR TITLE
Allow custom collage layouts from private folder

### DIFF
--- a/api/getCollageLayouts.php
+++ b/api/getCollageLayouts.php
@@ -1,0 +1,85 @@
+<?php
+
+require_once '../lib/boot.php';
+
+use Photobooth\Utility\PathUtility;
+
+header('Content-Type: application/json');
+
+$layouts = [];
+$seen = [];
+
+$readLayoutsFromDir = static function (string $dirPath) use (&$layouts, &$seen): void {
+    if (!is_dir($dirPath)) {
+        return;
+    }
+
+    $iterator = new DirectoryIterator($dirPath);
+    foreach ($iterator as $fileInfo) {
+        if (!$fileInfo->isFile()) {
+            continue;
+        }
+
+        if (strtolower($fileInfo->getExtension()) !== 'json') {
+            continue;
+        }
+
+        $layoutId = pathinfo($fileInfo->getFilename(), PATHINFO_FILENAME);
+        if ($layoutId === '') {
+            continue;
+        }
+
+        $label = $layoutId;
+        $contents = file_get_contents($fileInfo->getPathname());
+        if ($contents !== false) {
+            $decoded = json_decode($contents, true);
+            if (is_array($decoded) && isset($decoded['name']) && is_string($decoded['name']) && $decoded['name'] !== '') {
+                $label = $decoded['name'];
+            }
+        }
+
+        if (isset($seen[$layoutId])) {
+            $layouts[$seen[$layoutId]] = [
+                'id' => $layoutId,
+                'label' => $label,
+            ];
+            continue;
+        }
+
+        $layouts[] = [
+            'id' => $layoutId,
+            'label' => $label,
+        ];
+        $seen[$layoutId] = count($layouts) - 1;
+    }
+};
+
+$templateLayoutsDir = PathUtility::getAbsolutePath('template/collage');
+$templateOrientationDirs = [
+    $templateLayoutsDir . DIRECTORY_SEPARATOR . 'landscape',
+    $templateLayoutsDir . DIRECTORY_SEPARATOR . 'portrait',
+];
+
+$privateLayoutsDir = PathUtility::getAbsolutePath('private/collage/layouts');
+$privateOrientationDirs = [
+    $privateLayoutsDir . DIRECTORY_SEPARATOR . 'landscape',
+    $privateLayoutsDir . DIRECTORY_SEPARATOR . 'portrait',
+];
+
+foreach ($privateOrientationDirs as $orientationDir) {
+    $readLayoutsFromDir($orientationDir);
+}
+$readLayoutsFromDir($privateLayoutsDir);
+
+foreach ($templateOrientationDirs as $orientationDir) {
+    $readLayoutsFromDir($orientationDir);
+}
+$readLayoutsFromDir($templateLayoutsDir);
+
+usort($layouts, static function (array $left, array $right): int {
+    return strnatcasecmp($left['label'], $right['label']);
+});
+
+echo json_encode($layouts);
+
+exit();

--- a/api/getCollageLayouts.php
+++ b/api/getCollageLayouts.php
@@ -58,6 +58,24 @@ function loadCollageLayoutData(string $layoutId, string $orientation): ?array
     return null;
 }
 
+function ensurePrivateLayoutDirectories(): void
+{
+    $directories = [
+        'private/collage/layouts',
+        'private/collage/layouts/landscape',
+        'private/collage/layouts/portrait',
+    ];
+
+    foreach ($directories as $directory) {
+        $absolutePath = PathUtility::getAbsolutePath($directory);
+        if (is_dir($absolutePath)) {
+            continue;
+        }
+
+        @mkdir($absolutePath, 0775, true);
+    }
+}
+
 function buildCollageLayoutPreviewSvg(string $layoutId, ?array $layoutData): string
 {
     if (!is_array($layoutData) || empty($layoutData['layout']) || !is_array($layoutData['layout'])) {
@@ -184,6 +202,8 @@ function buildCollageLayoutPreviewSvg(string $layoutId, ?array $layoutData): str
 $layouts = [];
 $seen = [];
 
+ensurePrivateLayoutDirectories();
+
 $readLayoutsFromDir = static function (string $dirPath, bool $isPrivateSource) use (&$layouts, &$seen): void {
     if (!is_dir($dirPath)) {
         return;
@@ -250,6 +270,12 @@ $privateOrientationDirs = [
     $privateLayoutsDir . DIRECTORY_SEPARATOR . 'portrait',
 ];
 
+$legacyPrivateCollageDir = PathUtility::getAbsolutePath('private/collage');
+$legacyPrivateOrientationDirs = [
+    $legacyPrivateCollageDir . DIRECTORY_SEPARATOR . 'landscape',
+    $legacyPrivateCollageDir . DIRECTORY_SEPARATOR . 'portrait',
+];
+
 foreach ($templateOrientationDirs as $orientationDir) {
     $readLayoutsFromDir($orientationDir, false);
 }
@@ -259,6 +285,11 @@ foreach ($privateOrientationDirs as $orientationDir) {
     $readLayoutsFromDir($orientationDir, true);
 }
 $readLayoutsFromDir($privateLayoutsDir, true);
+
+foreach ($legacyPrivateOrientationDirs as $orientationDir) {
+    $readLayoutsFromDir($orientationDir, true);
+}
+$readLayoutsFromDir($legacyPrivateCollageDir, true);
 
 foreach ($layouts as &$layout) {
     $layoutId = (string) $layout['id'];

--- a/api/getCollageLayouts.php
+++ b/api/getCollageLayouts.php
@@ -9,7 +9,7 @@ header('Content-Type: application/json');
 $layouts = [];
 $seen = [];
 
-$readLayoutsFromDir = static function (string $dirPath) use (&$layouts, &$seen): void {
+$readLayoutsFromDir = static function (string $dirPath, bool $isPrivateSource) use (&$layouts, &$seen): void {
     if (!is_dir($dirPath)) {
         return;
     }
@@ -30,12 +30,21 @@ $readLayoutsFromDir = static function (string $dirPath) use (&$layouts, &$seen):
         }
 
         $label = $layoutId;
+        $isValidJson = true;
         $contents = file_get_contents($fileInfo->getPathname());
         if ($contents !== false) {
             $decoded = json_decode($contents, true);
-            if (is_array($decoded) && isset($decoded['name']) && is_string($decoded['name']) && $decoded['name'] !== '') {
+            if (json_last_error() !== JSON_ERROR_NONE || !is_array($decoded)) {
+                $isValidJson = false;
+            } elseif (isset($decoded['name']) && is_string($decoded['name']) && $decoded['name'] !== '') {
                 $label = $decoded['name'];
             }
+        } else {
+            $isValidJson = false;
+        }
+
+        if ($isPrivateSource && !$isValidJson) {
+            continue;
         }
 
         if (isset($seen[$layoutId])) {
@@ -66,15 +75,15 @@ $privateOrientationDirs = [
     $privateLayoutsDir . DIRECTORY_SEPARATOR . 'portrait',
 ];
 
-foreach ($privateOrientationDirs as $orientationDir) {
-    $readLayoutsFromDir($orientationDir);
-}
-$readLayoutsFromDir($privateLayoutsDir);
-
 foreach ($templateOrientationDirs as $orientationDir) {
-    $readLayoutsFromDir($orientationDir);
+    $readLayoutsFromDir($orientationDir, false);
 }
-$readLayoutsFromDir($templateLayoutsDir);
+$readLayoutsFromDir($templateLayoutsDir, false);
+
+foreach ($privateOrientationDirs as $orientationDir) {
+    $readLayoutsFromDir($orientationDir, true);
+}
+$readLayoutsFromDir($privateLayoutsDir, true);
 
 usort($layouts, static function (array $left, array $right): int {
     return strnatcasecmp($left['label'], $right['label']);

--- a/api/getCollageLayouts.php
+++ b/api/getCollageLayouts.php
@@ -2,9 +2,184 @@
 
 require_once '../lib/boot.php';
 
+use Photobooth\Collage;
 use Photobooth\Utility\PathUtility;
 
 header('Content-Type: application/json');
+
+$allowedOrientations = ['landscape', 'portrait'];
+$requestedOrientation = isset($_GET['orientation']) ? (string) $_GET['orientation'] : 'landscape';
+$orientation = in_array($requestedOrientation, $allowedOrientations, true) ? $requestedOrientation : 'landscape';
+$fallbackOrientation = $orientation === 'landscape' ? 'portrait' : 'landscape';
+
+function evaluateCollageExpression(string $expr, float $x, float $y): float
+{
+    $expr = str_replace(['x', 'y'], [(string) $x, (string) $y], $expr);
+
+    try {
+        if (preg_match('/^[\d\.\+\-\*\/\(\)\s]+$/', $expr)) {
+            return (float) eval("return $expr;");
+        }
+    } catch (\Throwable $e) {
+        return 0.0;
+    }
+
+    return (float) $expr;
+}
+
+function loadCollageLayoutData(string $layoutId, string $orientation): ?array
+{
+    $jsonPath = Collage::getCollageConfigPath($layoutId, $orientation);
+
+    if ($jsonPath === null || !is_file($jsonPath)) {
+        return null;
+    }
+
+    $jsonContent = file_get_contents($jsonPath);
+    if ($jsonContent === false) {
+        return null;
+    }
+
+    $data = json_decode($jsonContent, true);
+    if (!is_array($data)) {
+        return null;
+    }
+
+    if (isset($data['layout']) && is_array($data['layout'])) {
+        return $data;
+    }
+
+    if (isset($data[0]) && is_array($data[0])) {
+        return [
+            'layout' => $data,
+        ];
+    }
+
+    return null;
+}
+
+function buildCollageLayoutPreviewSvg(string $layoutId, ?array $layoutData): string
+{
+    if (!is_array($layoutData) || empty($layoutData['layout']) || !is_array($layoutData['layout'])) {
+        $width = 1800;
+        $height = 1200;
+        $positions = [
+            ['x' => 0, 'y' => 0, 'w' => 90, 'h' => 60, 'num' => 1],
+            ['x' => 90, 'y' => 0, 'w' => 90, 'h' => 60, 'num' => 2],
+            ['x' => 0, 'y' => 60, 'w' => 90, 'h' => 60, 'num' => 3],
+            ['x' => 90, 'y' => 60, 'w' => 90, 'h' => 60, 'num' => 4],
+        ];
+    } else {
+        $width = (float) ($layoutData['width'] ?? 1800);
+        $height = (float) ($layoutData['height'] ?? 1200);
+        $scale = 0.1;
+
+        $layoutName = str_ends_with($layoutId, '.json') ? substr($layoutId, 0, -5) : $layoutId;
+        $isPhotostrip = str_starts_with($layoutName, '2x');
+        $layoutCount = count($layoutData['layout']);
+        $uniquePhotoCount = $isPhotostrip ? (int) ($layoutCount / 2) : $layoutCount;
+
+        $positions = [];
+        $photoNum = 1;
+
+        foreach ($layoutData['layout'] as $index => $photoLayout) {
+            if (!is_array($photoLayout) || count($photoLayout) < 4) {
+                continue;
+            }
+
+            $x = evaluateCollageExpression((string) $photoLayout[0], $width, $height);
+            $y = evaluateCollageExpression((string) $photoLayout[1], $width, $height);
+            $w = evaluateCollageExpression((string) $photoLayout[2], $width, $height);
+            $h = evaluateCollageExpression((string) $photoLayout[3], $width, $height);
+
+            $displayNum = $isPhotostrip && $index >= $uniquePhotoCount
+                ? ($index - $uniquePhotoCount + 1)
+                : $photoNum;
+
+            $positions[] = [
+                'x' => $x * $scale,
+                'y' => $y * $scale,
+                'w' => $w * $scale,
+                'h' => $h * $scale,
+                'num' => $displayNum,
+            ];
+
+            if (!$isPhotostrip || $index < $uniquePhotoCount - 1) {
+                $photoNum++;
+            } elseif ($index === $uniquePhotoCount - 1) {
+                $photoNum = 1;
+            }
+        }
+
+        if (empty($positions)) {
+            $positions = [
+                ['x' => 0, 'y' => 0, 'w' => 90, 'h' => 60, 'num' => 1],
+                ['x' => 90, 'y' => 0, 'w' => 90, 'h' => 60, 'num' => 2],
+                ['x' => 0, 'y' => 60, 'w' => 90, 'h' => 60, 'num' => 3],
+                ['x' => 90, 'y' => 60, 'w' => 90, 'h' => 60, 'num' => 4],
+            ];
+        }
+    }
+
+    $viewBoxWidth = $width * 0.1;
+    $viewBoxHeight = $height * 0.1;
+
+    $svg = sprintf(
+        '<svg class="collageSelector__preview" viewBox="0 0 %d %d" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">',
+        (int) round($viewBoxWidth),
+        (int) round($viewBoxHeight)
+    );
+
+    foreach ($positions as $pos) {
+        $svg .= sprintf(
+            '<rect x="%s" y="%s" width="%s" height="%s" fill="#4A90E2" stroke="#FFFFFF" stroke-width="2" rx="2"/>',
+            number_format($pos['x'] + 2, 1, '.', ''),
+            number_format($pos['y'] + 2, 1, '.', ''),
+            number_format($pos['w'] - 4, 1, '.', ''),
+            number_format($pos['h'] - 4, 1, '.', '')
+        );
+
+        $centerX = $pos['x'] + $pos['w'] / 2;
+        $centerY = $pos['y'] + $pos['h'] / 2;
+        $svg .= sprintf(
+            '<text x="%s" y="%s" text-anchor="middle" dominant-baseline="middle" fill="#FFFFFF" font-size="28" font-weight="bold" font-family="Arial, sans-serif">%d</text>',
+            number_format($centerX, 1, '.', ''),
+            number_format($centerY + 2, 1, '.', ''),
+            $pos['num']
+        );
+    }
+
+    $layoutName = str_ends_with($layoutId, '.json') ? substr($layoutId, 0, -5) : $layoutId;
+    $isPhotostrip = str_starts_with($layoutName, '2x');
+    if ($isPhotostrip) {
+        if ($width > $height) {
+            $middleY = $viewBoxHeight / 2;
+            $svg .= sprintf(
+                '<line x1="0" y1="%s" x2="%s" y2="%s" stroke="#FF0000" stroke-width="2" stroke-dasharray="5,5" opacity="0.8"/>',
+                number_format($middleY, 1, '.', ''),
+                number_format($viewBoxWidth, 1, '.', ''),
+                number_format($middleY, 1, '.', '')
+            );
+        } else {
+            $middleX = $viewBoxWidth / 2;
+            $svg .= sprintf(
+                '<line x1="%s" y1="0" x2="%s" y2="%s" stroke="#FF0000" stroke-width="2" stroke-dasharray="5,5" opacity="0.8"/>',
+                number_format($middleX, 1, '.', ''),
+                number_format($middleX, 1, '.', ''),
+                number_format($viewBoxHeight, 1, '.', '')
+            );
+        }
+    }
+
+    $svg .= sprintf(
+        '<rect x="0" y="0" width="%s" height="%s" fill="none" stroke="#666666" stroke-width="1" rx="2"/>',
+        number_format($viewBoxWidth, 1, '.', ''),
+        number_format($viewBoxHeight, 1, '.', '')
+    );
+    $svg .= '</svg>';
+
+    return $svg;
+}
 
 $layouts = [];
 $seen = [];
@@ -84,6 +259,19 @@ foreach ($privateOrientationDirs as $orientationDir) {
     $readLayoutsFromDir($orientationDir, true);
 }
 $readLayoutsFromDir($privateLayoutsDir, true);
+
+foreach ($layouts as &$layout) {
+    $layoutId = (string) $layout['id'];
+    $layoutData = loadCollageLayoutData($layoutId, $orientation);
+    if ($layoutData === null && $fallbackOrientation !== $orientation) {
+        $layoutData = loadCollageLayoutData($layoutId, $fallbackOrientation);
+    }
+    if (is_array($layoutData) && isset($layoutData['name']) && is_string($layoutData['name']) && $layoutData['name'] !== '') {
+        $layout['label'] = $layoutData['name'];
+    }
+    $layout['preview'] = buildCollageLayoutPreviewSvg($layoutId, $layoutData);
+}
+unset($layout);
 
 usort($layouts, static function (array $left, array $right): int {
     return strnatcasecmp($left['label'], $right['label']);

--- a/api/getCollageLayouts.php
+++ b/api/getCollageLayouts.php
@@ -258,6 +258,53 @@ $readLayoutsFromDir = static function (string $dirPath, bool $isPrivateSource) u
     }
 };
 
+$readLayoutFile = static function (string $filePath, bool $isPrivateSource) use (&$layouts, &$seen): void {
+    if (!is_file($filePath)) {
+        return;
+    }
+
+    if (strtolower((string) pathinfo($filePath, PATHINFO_EXTENSION)) !== 'json') {
+        return;
+    }
+
+    $layoutId = (string) pathinfo($filePath, PATHINFO_FILENAME);
+    if ($layoutId === '') {
+        return;
+    }
+
+    $label = $layoutId;
+    $isValidJson = true;
+    $contents = file_get_contents($filePath);
+    if ($contents !== false) {
+        $decoded = json_decode($contents, true);
+        if (json_last_error() !== JSON_ERROR_NONE || !is_array($decoded)) {
+            $isValidJson = false;
+        } elseif (isset($decoded['name']) && is_string($decoded['name']) && $decoded['name'] !== '') {
+            $label = $decoded['name'];
+        }
+    } else {
+        $isValidJson = false;
+    }
+
+    if ($isPrivateSource && !$isValidJson) {
+        return;
+    }
+
+    if (isset($seen[$layoutId])) {
+        $layouts[$seen[$layoutId]] = [
+            'id' => $layoutId,
+            'label' => $label,
+        ];
+        return;
+    }
+
+    $layouts[] = [
+        'id' => $layoutId,
+        'label' => $label,
+    ];
+    $seen[$layoutId] = count($layouts) - 1;
+};
+
 $templateLayoutsDir = PathUtility::getAbsolutePath('template/collage');
 $templateOrientationDirs = [
     $templateLayoutsDir . DIRECTORY_SEPARATOR . 'landscape',
@@ -275,6 +322,7 @@ $legacyPrivateOrientationDirs = [
     $legacyPrivateCollageDir . DIRECTORY_SEPARATOR . 'landscape',
     $legacyPrivateCollageDir . DIRECTORY_SEPARATOR . 'portrait',
 ];
+$legacyPrivateRootCollageJson = PathUtility::getAbsolutePath('private/collage.json');
 
 foreach ($templateOrientationDirs as $orientationDir) {
     $readLayoutsFromDir($orientationDir, false);
@@ -290,6 +338,7 @@ foreach ($legacyPrivateOrientationDirs as $orientationDir) {
     $readLayoutsFromDir($orientationDir, true);
 }
 $readLayoutsFromDir($legacyPrivateCollageDir, true);
+$readLayoutFile($legacyPrivateRootCollageJson, true);
 
 foreach ($layouts as &$layout) {
     $layoutId = (string) $layout['id'];

--- a/assets/js/admin/index.js
+++ b/assets/js/admin/index.js
@@ -45,7 +45,11 @@ function initCollageLayoutOptions() {
 }
 
 function fetchCollageLayouts() {
-    const url = environment.publicFolders.api + '/getCollageLayouts.php';
+    let orientation = 'landscape';
+    if (typeof config !== 'undefined' && config.collage && config.collage.orientation) {
+        orientation = String(config.collage.orientation);
+    }
+    const url = environment.publicFolders.api + '/getCollageLayouts.php?orientation=' + encodeURIComponent(orientation);
     return new Promise(function (resolve) {
         $.ajax({
             url: url,
@@ -116,21 +120,23 @@ function updateCollageLayoutsEnabled(gridEl, layouts) {
         seen[id] = true;
         ordered.push({
             id: id,
-            label: layout.label ? String(layout.label) : id
+            label: layout.label ? String(layout.label) : id,
+            preview: layout.preview ? String(layout.preview) : ''
         });
     });
     selected.forEach(function (id) {
         if (!seen[id]) {
             ordered.push({
                 id: id,
-                label: id
+                label: id,
+                preview: ''
             });
         }
     });
     gridEl.innerHTML = '';
     ordered.forEach(function (layout) {
         const isSelected = selected.indexOf(layout.id) !== -1;
-        gridEl.appendChild(buildLayoutToggleOption(layout.id, layout.label, isSelected));
+        gridEl.appendChild(buildLayoutToggleOption(layout.id, layout.label, isSelected, layout.preview));
     });
     bindToggleButtons(gridEl);
     setupAllowSelectionGuard(gridEl);
@@ -147,7 +153,7 @@ function readSelectedLayouts() {
     return selected;
 }
 
-function buildLayoutToggleOption(layoutId, label, isSelected) {
+function buildLayoutToggleOption(layoutId, label, isSelected, previewSvg) {
     const wrapper = document.createElement('label');
     wrapper.className = 'relative cursor-pointer';
     const input = document.createElement('input');
@@ -162,8 +168,31 @@ function buildLayoutToggleOption(layoutId, label, isSelected) {
         ? 'bg-brand-1 text-white border-brand-1'
         : 'bg-white text-gray-700 border-gray-300 hover:border-brand-1';
     const button = document.createElement('div');
-    button.className = 'toggle-button px-3 py-1.5 border text-sm rounded-md text-center transition-all ' + activeClass;
-    button.textContent = label;
+    button.className = 'toggle-button px-3 py-2 border text-sm rounded-md text-center transition-all ' + activeClass;
+    button.style.display = 'flex';
+    button.style.flexDirection = 'column';
+    button.style.alignItems = 'center';
+    button.style.gap = '0.5rem';
+    if (previewSvg) {
+        const preview = document.createElement('div');
+        preview.className = 'bg-white border border-gray-200 rounded overflow-hidden';
+        preview.style.display = 'flex';
+        preview.style.alignItems = 'center';
+        preview.style.justifyContent = 'center';
+        preview.style.width = '112px';
+        preview.style.height = '80px';
+        preview.innerHTML = previewSvg;
+        const previewSvgNode = preview.querySelector('svg');
+        if (previewSvgNode) {
+            previewSvgNode.setAttribute('width', '112');
+            previewSvgNode.setAttribute('height', '80');
+        }
+        button.appendChild(preview);
+    }
+    const labelEl = document.createElement('div');
+    labelEl.className = 'text-xs font-medium';
+    labelEl.textContent = label;
+    button.appendChild(labelEl);
     wrapper.appendChild(input);
     wrapper.appendChild(button);
     return wrapper;

--- a/assets/js/admin/index.js
+++ b/assets/js/admin/index.js
@@ -1,4 +1,5 @@
 /* globals photoboothTools csrf */
+/* eslint-env browser */
 $(function () {
     initDirtyTracking();
 
@@ -18,7 +19,239 @@ $(function () {
             $('.adminCheckbox-false', this).removeClass('hidden');
         }
     });
+    initCollageLayoutOptions();
 });
+
+function initCollageLayoutOptions() {
+    if (typeof environment === 'undefined' || !environment.publicFolders || !environment.publicFolders.api) {
+        return;
+    }
+    const layoutSelect = document.querySelector('select[name="collage[layout]"]');
+    const layoutGrid = document.querySelector('[data-setting-name="collage[layouts_enabled]"]');
+    if (!layoutSelect && !layoutGrid) {
+        return;
+    }
+    fetchCollageLayouts().then(function (layouts) {
+        if (!layouts) {
+            return;
+        }
+        if (layoutSelect) {
+            updateCollageLayoutSelect(layoutSelect, layouts);
+        }
+        if (layoutGrid) {
+            updateCollageLayoutsEnabled(layoutGrid, layouts);
+        }
+    });
+}
+
+function fetchCollageLayouts() {
+    const url = environment.publicFolders.api + '/getCollageLayouts.php';
+    return new Promise(function (resolve) {
+        $.ajax({
+            url: url,
+            method: 'GET',
+            cache: false,
+            dataType: 'json'
+        })
+            .done(function (data) {
+                resolve(Array.isArray(data) ? data : []);
+            })
+            .fail(function () {
+                resolve(null);
+            });
+    });
+}
+
+function updateCollageLayoutSelect(selectEl, layouts) {
+    let currentValue = selectEl.value;
+    if ((!currentValue || currentValue === '') && typeof config !== 'undefined' && config.collage) {
+        currentValue = String(config.collage.layout || '');
+    }
+    const ordered = [];
+    const seen = {};
+    layouts.forEach(function (layout) {
+        if (!layout || !layout.id) {
+            return;
+        }
+        const id = String(layout.id);
+        if (seen[id]) {
+            return;
+        }
+        seen[id] = true;
+        ordered.push({
+            id: id,
+            label: layout.label ? String(layout.label) : id
+        });
+    });
+    if (currentValue && !seen[currentValue]) {
+        ordered.push({
+            id: currentValue,
+            label: currentValue
+        });
+    }
+    selectEl.innerHTML = '';
+    ordered.forEach(function (layout) {
+        const option = document.createElement('option');
+        option.value = layout.id;
+        option.textContent = layout.label;
+        if (layout.id === currentValue) {
+            option.selected = true;
+        }
+        selectEl.appendChild(option);
+    });
+}
+
+function updateCollageLayoutsEnabled(gridEl, layouts) {
+    const selected = readSelectedLayouts();
+    const ordered = [];
+    const seen = {};
+    layouts.forEach(function (layout) {
+        if (!layout || !layout.id) {
+            return;
+        }
+        const id = String(layout.id);
+        if (seen[id]) {
+            return;
+        }
+        seen[id] = true;
+        ordered.push({
+            id: id,
+            label: layout.label ? String(layout.label) : id
+        });
+    });
+    selected.forEach(function (id) {
+        if (!seen[id]) {
+            ordered.push({
+                id: id,
+                label: id
+            });
+        }
+    });
+    gridEl.innerHTML = '';
+    ordered.forEach(function (layout) {
+        const isSelected = selected.indexOf(layout.id) !== -1;
+        gridEl.appendChild(buildLayoutToggleOption(layout.id, layout.label, isSelected));
+    });
+    bindToggleButtons(gridEl);
+    setupAllowSelectionGuard(gridEl);
+}
+
+function readSelectedLayouts() {
+    if (typeof config !== 'undefined' && config.collage && Array.isArray(config.collage.layouts_enabled)) {
+        return config.collage.layouts_enabled.map((value) => String(value));
+    }
+    const selected = [];
+    document.querySelectorAll('input[name="collage[layouts_enabled][]"]:checked').forEach(function (checkbox) {
+        selected.push(checkbox.value);
+    });
+    return selected;
+}
+
+function buildLayoutToggleOption(layoutId, label, isSelected) {
+    const wrapper = document.createElement('label');
+    wrapper.className = 'relative cursor-pointer';
+    const input = document.createElement('input');
+    input.type = 'checkbox';
+    input.name = 'collage[layouts_enabled][]';
+    input.value = layoutId;
+    input.className = 'hidden toggle-checkbox';
+    if (isSelected) {
+        input.checked = true;
+    }
+    const activeClass = isSelected
+        ? 'bg-brand-1 text-white border-brand-1'
+        : 'bg-white text-gray-700 border-gray-300 hover:border-brand-1';
+    const button = document.createElement('div');
+    button.className = 'toggle-button px-3 py-1.5 border text-sm rounded-md text-center transition-all ' + activeClass;
+    button.textContent = label;
+    wrapper.appendChild(input);
+    wrapper.appendChild(button);
+    return wrapper;
+}
+
+function bindToggleButtons(container) {
+    container.querySelectorAll('.toggle-checkbox').forEach(function (checkbox) {
+        checkbox.addEventListener('change', function () {
+            const button = this.nextElementSibling;
+            if (!button) {
+                return;
+            }
+            if (this.checked) {
+                button.classList.remove('bg-white', 'text-gray-700', 'border-gray-300', 'hover:border-brand-1');
+                button.classList.add('bg-brand-1', 'text-white', 'border-brand-1');
+            } else {
+                button.classList.remove('bg-brand-1', 'text-white', 'border-brand-1');
+                button.classList.add('bg-white', 'text-gray-700', 'border-gray-300', 'hover:border-brand-1');
+            }
+        });
+        const button = checkbox.nextElementSibling;
+        if (button) {
+            button.addEventListener('click', function (event) {
+                event.preventDefault();
+                checkbox.click();
+            });
+        }
+    });
+}
+
+function setupAllowSelectionGuard(container) {
+    const allowSelection = document.querySelector('input[type="checkbox"][name="collage[allow_selection]"]');
+    if (!allowSelection) {
+        return;
+    }
+    const allowWrapper = allowSelection.closest('.adminCheckbox');
+    const warningId = 'collage-allow-selection-warning';
+    let warning = document.getElementById(warningId);
+    if (!warning && allowWrapper) {
+        warning = document.createElement('div');
+        warning.id = warningId;
+        warning.className = 'mt-2 text-xs text-red-600';
+        warning.style.display = 'none';
+        if (typeof photoboothTools !== 'undefined' && photoboothTools.getTranslation) {
+            warning.textContent = photoboothTools.getTranslation('collage_select_min_two_layouts');
+        } else {
+            warning.textContent = 'Select at least two layouts to enable selection.';
+        }
+        allowWrapper.insertAdjacentElement('afterend', warning);
+    }
+    const syncAllowToggleText = function (isChecked) {
+        if (!allowWrapper) {
+            return;
+        }
+        const onLabel = allowWrapper.querySelector('.adminCheckbox-true');
+        const offLabel = allowWrapper.querySelector('.adminCheckbox-false');
+        if (onLabel && offLabel) {
+            if (isChecked) {
+                onLabel.classList.remove('hidden');
+                offLabel.classList.add('hidden');
+            } else {
+                onLabel.classList.add('hidden');
+                offLabel.classList.remove('hidden');
+            }
+        }
+    };
+    const getUniqueSelectedLayoutCount = function () {
+        const checked = container.querySelectorAll('input[type="checkbox"][name="collage[layouts_enabled][]"]:checked');
+        const values = new Set();
+        checked.forEach((checkbox) => values.add(checkbox.value));
+        return values.size;
+    };
+    const guardAllowSelection = function () {
+        const count = getUniqueSelectedLayoutCount();
+        if (warning) {
+            warning.style.display = count < 2 ? 'block' : 'none';
+        }
+        if (allowSelection.checked && count < 2) {
+            allowSelection.checked = false;
+            syncAllowToggleText(false);
+        }
+    };
+    allowSelection.addEventListener('change', guardAllowSelection);
+    container.querySelectorAll('.toggle-checkbox').forEach((checkbox) => {
+        checkbox.addEventListener('change', guardAllowSelection);
+    });
+    guardAllowSelection();
+}
 
 // eslint-disable-next-line no-unused-vars
 const shellCommand = function ($mode, $filename = '') {

--- a/lib/configsetup.inc.php
+++ b/lib/configsetup.inc.php
@@ -1,6 +1,5 @@
 <?php
 
-use Photobooth\Enum\CollageLayoutEnum;
 use Photobooth\Enum\ImageFilterEnum;
 use Photobooth\Enum\MailSecurityTypeEnum;
 use Photobooth\Enum\RemoteStorageTypeEnum;
@@ -105,6 +104,27 @@ if (is_file($mailDb)) {
 $printManager = PrintManagerService::getInstance();
 $printDbCount = $printManager->getPrintCountFromDB() ?? 0;
 $languageService = LanguageService::getInstance();
+
+$normalizeLayoutValue = static function ($value): string {
+    return $value instanceof \BackedEnum ? (string) $value->value : (string) $value;
+};
+
+$layoutSelectOptions = [];
+$currentLayoutValue = $normalizeLayoutValue($config['collage']['layout'] ?? '');
+if ($currentLayoutValue !== '') {
+    $layoutSelectOptions[$currentLayoutValue] = $currentLayoutValue;
+}
+
+$layoutsEnabledOptions = [];
+$layoutsEnabledValues = $config['collage']['layouts_enabled'] ?? [];
+$layoutsEnabledValues = is_array($layoutsEnabledValues) ? $layoutsEnabledValues : [];
+foreach ($layoutsEnabledValues as $layoutValue) {
+    $layoutValue = trim($normalizeLayoutValue($layoutValue));
+    if ($layoutValue === '') {
+        continue;
+    }
+    $layoutsEnabledOptions[$layoutValue] = $layoutValue;
+}
 
 return [
     'general' => [
@@ -986,7 +1006,7 @@ return [
             'name' => 'collage[layout]',
             'data-theme-field' => 'true',
             'placeholder' => $defaultConfig['collage']['layout'],
-            'options' => CollageLayoutEnum::cases(),
+            'options' => $layoutSelectOptions,
             'value' => $config['collage']['layout'],
         ],
         'collage_allow_selection' => [
@@ -1001,7 +1021,7 @@ return [
             'name' => 'collage[layouts_enabled]',
             'button_label' => 'choose_layouts',
             'placeholder' => $defaultConfig['collage']['layouts_enabled'],
-            'options' => CollageLayoutEnum::cases(),
+            'options' => $layoutsEnabledOptions,
             'preview_orientation' => $config['collage']['orientation'] ?? 'landscape',
             'value' => $config['collage']['layouts_enabled'],
         ],

--- a/src/Collage.php
+++ b/src/Collage.php
@@ -172,10 +172,7 @@ class Collage
 
         $layoutName = str_ends_with($layoutId, '.json') ? substr($layoutId, 0, -5) : $layoutId;
 
-        self::$drawDashedLine =
-            $layoutName === '2x4-2' ||
-            $layoutName === '2x4-3' ||
-            $layoutName === '2x3-1';
+        self::$drawDashedLine = str_starts_with($layoutName, '2x');
 
         $layoutFile = str_ends_with($layoutId, '.json') ? $layoutId : $layoutId . '.json';
 
@@ -568,15 +565,66 @@ class Collage
             self::$collageWidth = (int) imagesx($my_collage);
             self::$collageHeight = (int) imagesy($my_collage);
             $imageHandler->dashedLineColor = (string)imagecolorallocate($my_collage, (int)$dashed_r, (int)$dashed_g, (int)$dashed_b);
+            $replace = ['x' => self::$collageWidth, 'y' => self::$collageHeight];
             if (self::$pictureOrientation === 'portrait') {
+                $midY = self::$collageHeight / 2;
+                if (isset($layoutConfigArray) && is_array($layoutConfigArray)) {
+                    $layoutCount = count($layoutConfigArray);
+                    $uniquePhotoCount = (int) ($layoutCount / 2);
+                    $topMax = null;
+                    $bottomMin = null;
+
+                    for ($i = 0; $i < $layoutCount; $i++) {
+                        $entry = $layoutConfigArray[$i];
+                        if (!is_array($entry) || count($entry) < 4) {
+                            continue;
+                        }
+                        $y = (float) Helper::doMath(str_replace(array_keys($replace), array_values($replace), $entry[1]));
+                        $h = (float) Helper::doMath(str_replace(array_keys($replace), array_values($replace), $entry[3]));
+                        if ($i < $uniquePhotoCount) {
+                            $topMax = $topMax === null ? ($y + $h) : max($topMax, $y + $h);
+                        } else {
+                            $bottomMin = $bottomMin === null ? $y : min($bottomMin, $y);
+                        }
+                    }
+
+                    if ($topMax !== null && $bottomMin !== null) {
+                        $midY = ($topMax + $bottomMin) / 2;
+                    }
+                }
                 $imageHandler->dashedLineStartX = intval(self::$collageWidth * 0.03);
-                $imageHandler->dashedLineStartY = intval(self::$collageHeight / 2);
+                $imageHandler->dashedLineStartY = (int) round($midY);
                 $imageHandler->dashedLineEndX = intval(self::$collageWidth * 0.97);
-                $imageHandler->dashedLineEndY = intval(self::$collageHeight / 2);
+                $imageHandler->dashedLineEndY = (int) round($midY);
             } else {
-                $imageHandler->dashedLineStartX = intval(self::$collageWidth / 2);
+                $midX = self::$collageWidth / 2;
+                if (isset($layoutConfigArray) && is_array($layoutConfigArray)) {
+                    $layoutCount = count($layoutConfigArray);
+                    $uniquePhotoCount = (int) ($layoutCount / 2);
+                    $leftMax = null;
+                    $rightMin = null;
+
+                    for ($i = 0; $i < $layoutCount; $i++) {
+                        $entry = $layoutConfigArray[$i];
+                        if (!is_array($entry) || count($entry) < 4) {
+                            continue;
+                        }
+                        $x = (float) Helper::doMath(str_replace(array_keys($replace), array_values($replace), $entry[0]));
+                        $w = (float) Helper::doMath(str_replace(array_keys($replace), array_values($replace), $entry[2]));
+                        if ($i < $uniquePhotoCount) {
+                            $leftMax = $leftMax === null ? ($x + $w) : max($leftMax, $x + $w);
+                        } else {
+                            $rightMin = $rightMin === null ? $x : min($rightMin, $x);
+                        }
+                    }
+
+                    if ($leftMax !== null && $rightMin !== null) {
+                        $midX = ($leftMax + $rightMin) / 2;
+                    }
+                }
+                $imageHandler->dashedLineStartX = (int) round($midX);
                 $imageHandler->dashedLineStartY = 0;
-                $imageHandler->dashedLineEndX = intval(self::$collageWidth / 2);
+                $imageHandler->dashedLineEndX = (int) round($midX);
                 $imageHandler->dashedLineEndY = intval(self::$collageHeight);
             }
             $imageHandler->drawDashedLine($my_collage);
@@ -626,6 +674,30 @@ class Collage
                     // Landscape: duplicate horizontally (shift X to right half)
                     $origX = $imageHandler->fontLocationX;
                     $shift = (int) (self::$collageWidth / 2);
+                    if (isset($layoutConfigArray) && is_array($layoutConfigArray)) {
+                        $layoutCount = count($layoutConfigArray);
+                        $uniquePhotoCount = (int) ($layoutCount / 2);
+                        $firstX = null;
+                        $secondX = null;
+                        $replace = ['x' => self::$collageWidth, 'y' => self::$collageHeight];
+
+                        for ($i = 0; $i < $layoutCount; $i++) {
+                            $entry = $layoutConfigArray[$i];
+                            if (!is_array($entry) || count($entry) < 2) {
+                                continue;
+                            }
+                            $x = (float) Helper::doMath(str_replace(array_keys($replace), array_values($replace), $entry[0]));
+                            if ($i < $uniquePhotoCount) {
+                                $firstX = $firstX === null ? $x : min($firstX, $x);
+                            } else {
+                                $secondX = $secondX === null ? $x : min($secondX, $x);
+                            }
+                        }
+
+                        if ($firstX !== null && $secondX !== null) {
+                            $shift = (int) round($secondX - $firstX);
+                        }
+                    }
                     $imageHandler->fontLocationX = $origX + $shift;
 
                     // Apply text again with zone mode support
@@ -646,6 +718,30 @@ class Collage
                     // Portrait: duplicate vertically (shift Y to bottom half)
                     $origY = $imageHandler->fontLocationY;
                     $shift = (int) (self::$collageHeight / 2);
+                    if (isset($layoutConfigArray) && is_array($layoutConfigArray)) {
+                        $layoutCount = count($layoutConfigArray);
+                        $uniquePhotoCount = (int) ($layoutCount / 2);
+                        $firstY = null;
+                        $secondY = null;
+                        $replace = ['x' => self::$collageWidth, 'y' => self::$collageHeight];
+
+                        for ($i = 0; $i < $layoutCount; $i++) {
+                            $entry = $layoutConfigArray[$i];
+                            if (!is_array($entry) || count($entry) < 2) {
+                                continue;
+                            }
+                            $y = (float) Helper::doMath(str_replace(array_keys($replace), array_values($replace), $entry[1]));
+                            if ($i < $uniquePhotoCount) {
+                                $firstY = $firstY === null ? $y : min($firstY, $y);
+                            } else {
+                                $secondY = $secondY === null ? $y : min($secondY, $y);
+                            }
+                        }
+
+                        if ($firstY !== null && $secondY !== null) {
+                            $shift = (int) round($secondY - $firstY);
+                        }
+                    }
                     $imageHandler->fontLocationY = $origY + $shift;
 
                     // Apply text again with zone mode support

--- a/src/Collage.php
+++ b/src/Collage.php
@@ -19,6 +19,61 @@ class Collage
     public static bool $rotateAfterCreation = false;
     public static string $layoutPath = '';
 
+    private static function normalizeLayoutId(string $layoutId): ?string
+    {
+        $layoutId = trim($layoutId);
+        if ($layoutId === '') {
+            return null;
+        }
+
+        if (str_contains($layoutId, "\0")) {
+            return null;
+        }
+
+        if (str_contains($layoutId, '/') || str_contains($layoutId, '\\')) {
+            return null;
+        }
+
+        return $layoutId;
+    }
+
+    private static function isLayoutsPath(string $path): bool
+    {
+        $layoutsDir = PathUtility::getAbsolutePath('private/collage/layouts');
+        $layoutsRoot = rtrim($layoutsDir, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR;
+
+        return str_starts_with($path, $layoutsRoot);
+    }
+
+    private static function getLegacyCollageConfigPath(string $layoutId, string $pictureOrientation): ?string
+    {
+        $layoutId = self::normalizeLayoutId($layoutId);
+        if ($layoutId === null) {
+            return null;
+        }
+
+        $layoutFile = str_ends_with($layoutId, '.json') ? $layoutId : $layoutId . '.json';
+
+        $relativePaths = [
+            'private/collage/' . $pictureOrientation . '/' . $layoutFile,
+            'private/collage/' . $layoutFile,
+            'private/' . $layoutFile,
+            'template/collage/' . $pictureOrientation . '/' . $layoutFile,
+            'template/collage/' . $layoutFile,
+        ];
+
+        foreach ($relativePaths as $relativePath) {
+            $absolutePath = PathUtility::getAbsolutePath($relativePath);
+
+            if (file_exists($absolutePath)) {
+                self::$layoutPath = $absolutePath;
+                return $absolutePath;
+            }
+        }
+
+        return null;
+    }
+
     public static function reset(): void
     {
         self::$collageHeight = 0;
@@ -60,6 +115,13 @@ class Collage
 
         if ($collageConfigFilePath !== null) {
             $collageJson = json_decode((string) file_get_contents($collageConfigFilePath), true);
+            if (!is_array($collageJson) && self::isLayoutsPath($collageConfigFilePath)) {
+                $legacyPath = self::getLegacyCollageConfigPath($layout, $orientation);
+                if ($legacyPath !== null && $legacyPath !== $collageConfigFilePath) {
+                    $collageJson = json_decode((string) file_get_contents($legacyPath), true);
+                }
+            }
+
             if (is_array($collageJson)) {
                 $layoutConfigArray = !empty($collageJson['layout'])
                     ? $collageJson['layout']
@@ -103,33 +165,40 @@ class Collage
 
     public static function getCollageConfigPath(string $collageLayout, string $pictureOrientation): ?string
     {
-        self::$drawDashedLine =
-            $collageLayout === '2x4-2' ||
-            $collageLayout === '2x4-3' ||
-            $collageLayout === '2x3-1';
-
-        if (!str_ends_with($collageLayout, '.json')) {
-            $collageLayout .= '.json';
+        $layoutId = self::normalizeLayoutId($collageLayout);
+        if ($layoutId === null) {
+            return null;
         }
 
-        $relativePaths = [
-            'private/collage/' . $pictureOrientation . '/' . $collageLayout,
-            'private/collage/' . $collageLayout,
-            'private/' . $collageLayout,
-            'template/collage/' . $pictureOrientation . '/' . $collageLayout,
-            'template/collage/' . $collageLayout,
+        $layoutName = str_ends_with($layoutId, '.json') ? substr($layoutId, 0, -5) : $layoutId;
+
+        self::$drawDashedLine =
+            $layoutName === '2x4-2' ||
+            $layoutName === '2x4-3' ||
+            $layoutName === '2x3-1';
+
+        $layoutFile = str_ends_with($layoutId, '.json') ? $layoutId : $layoutId . '.json';
+
+        $layoutsDir = PathUtility::getAbsolutePath('private/collage/layouts');
+        $orientationLayoutsDir = $layoutsDir . DIRECTORY_SEPARATOR . $pictureOrientation;
+        $layoutCandidates = [
+            $orientationLayoutsDir . DIRECTORY_SEPARATOR . $layoutFile,
+            $layoutsDir . DIRECTORY_SEPARATOR . $layoutFile,
         ];
 
-        foreach ($relativePaths as $relativePath) {
-            $absolutePath = PathUtility::getAbsolutePath($relativePath);
-
-            if (file_exists($absolutePath)) {
-                self::$layoutPath = $absolutePath;
-                return $absolutePath;
+        foreach ($layoutCandidates as $layoutCandidate) {
+            if (!is_file($layoutCandidate)) {
+                continue;
+            }
+            $realLayoutCandidate = realpath($layoutCandidate);
+            $layoutsRoot = rtrim($layoutsDir, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR;
+            if ($realLayoutCandidate !== false && str_starts_with($realLayoutCandidate, $layoutsRoot)) {
+                self::$layoutPath = $realLayoutCandidate;
+                return $realLayoutCandidate;
             }
         }
 
-        return null;
+        return self::getLegacyCollageConfigPath($layoutId, $pictureOrientation);
     }
 
     public static function createCollage(array $config, array $srcImagePaths, string $destImagePath, ?ImageFilterEnum $filter = null, ?CollageConfig $c = null): bool
@@ -152,6 +221,12 @@ class Collage
 
         if ($collageConfigFilePath !== null) {
             $collageJson = json_decode((string)file_get_contents($collageConfigFilePath), true);
+            if (!is_array($collageJson) && self::isLayoutsPath($collageConfigFilePath)) {
+                $legacyPath = self::getLegacyCollageConfigPath($c->collageLayout, self::$pictureOrientation);
+                if ($legacyPath !== null && $legacyPath !== $collageConfigFilePath) {
+                    $collageJson = json_decode((string)file_get_contents($legacyPath), true);
+                }
+            }
 
             if (is_array($collageJson)) {
                 if (isset($collageJson['layout']) && !empty($collageJson['layout'])) {

--- a/src/Configuration/Section/CollageConfiguration.php
+++ b/src/Configuration/Section/CollageConfiguration.php
@@ -2,7 +2,6 @@
 
 namespace Photobooth\Configuration\Section;
 
-use Photobooth\Enum\CollageLayoutEnum;
 use Symfony\Component\Config\Definition\Builder\NodeDefinition;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 
@@ -60,28 +59,26 @@ final class CollageConfiguration
                     ->values(['landscape', 'portrait'])
                     ->defaultValue('landscape')
                     ->end()
-                ->enumNode('layout')
-                    ->values(CollageLayoutEnum::cases())
-                    ->defaultValue(CollageLayoutEnum::TWO_PLUS_TWO_2)
+                ->scalarNode('layout')
+                    ->defaultValue('2+2-2')
                     ->beforeNormalization()
                         ->always(function ($value) {
-                            if (is_string($value)) {
-                                $value = CollageLayoutEnum::from($value);
+                            if ($value instanceof \BackedEnum) {
+                                return (string) $value->value;
                             }
-                            return $value;
+                            return (string) $value;
                         })
                         ->end()
                     ->end()
                 ->booleanNode('allow_selection')->defaultValue(false)->end()
                 ->arrayNode('layouts_enabled')
-                    ->enumPrototype()
-                        ->values(CollageLayoutEnum::cases())
+                    ->scalarPrototype()
                         ->beforeNormalization()
                             ->always(function ($value) {
-                                if (is_string($value)) {
-                                    $value = CollageLayoutEnum::from($value);
+                                if ($value instanceof \BackedEnum) {
+                                    return (string) $value->value;
                                 }
-                                return $value;
+                                return (string) $value;
                             })
                             ->end()
                         ->end()

--- a/src/Factory/CollageConfigFactory.php
+++ b/src/Factory/CollageConfigFactory.php
@@ -3,7 +3,6 @@
 namespace Photobooth\Factory;
 
 use Photobooth\Dto\CollageConfig;
-use Photobooth\Enum\CollageLayoutEnum;
 use Photobooth\Utility\PathUtility;
 
 class CollageConfigFactory
@@ -11,9 +10,10 @@ class CollageConfigFactory
     public static function fromConfig(array $config): CollageConfig
     {
         $collageConfig = new CollageConfig();
-        $collageConfig->collageLayout = $config['collage']['layout'] instanceof CollageLayoutEnum
-            ? $config['collage']['layout']->value
-            : (string) $config['collage']['layout'];
+        $layout = $config['collage']['layout'];
+        $collageConfig->collageLayout = $layout instanceof \BackedEnum
+            ? (string) $layout->value
+            : (string) $layout;
         $collageConfig->collageOrientation = $config['collage']['orientation'];
         $collageConfig->collageBackgroundColor = $config['collage']['background_color'];
         $collageConfig->collageFrame = $config['collage']['frame'];

--- a/src/Utility/AdminInput.php
+++ b/src/Utility/AdminInput.php
@@ -824,7 +824,7 @@ class AdminInput
                         </div>
 
                         <div class="flex w-full h-full flex-col overflow-y-auto">
-                            <div id="' . $gridId . '" class="' . $gridClass . '" style="grid-template-columns:repeat(auto-fill,minmax(192px,1fr));">
+                            <div id="' . $gridId . '" class="' . $gridClass . '" data-setting-name="' . htmlspecialchars($settingName, ENT_QUOTES) . '" style="grid-template-columns:repeat(auto-fill,minmax(192px,1fr));">
                                 ' . $buttons . '
                             </div>
                         </div>
@@ -987,7 +987,7 @@ class AdminInput
             : 'grid grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-2 mt-2';
 
         return self::renderHeadline($label) . '
-            <div id="' . $uniqueId . '" class="' . $gridClass . '">
+            <div id="' . $uniqueId . '" class="' . $gridClass . '" data-setting-name="' . htmlspecialchars($settingName, ENT_QUOTES) . '">
                 ' . $buttons . '
             </div>
             <script>

--- a/template/components/collageSelection.php
+++ b/template/components/collageSelection.php
@@ -59,6 +59,7 @@ function loadCollageLayoutFromJson(string $layoutId, string $orientation = 'land
  */
 function getLayoutPreviewSvg(string $layoutId, string $orientation = 'landscape', ?array $layoutData = null): string
 {
+    $isPhotostrip = false;
     // Try to load layout from JSON
     if ($layoutData === null) {
         $layoutData = loadCollageLayoutFromJson($layoutId, $orientation);

--- a/template/components/collageSelection.php
+++ b/template/components/collageSelection.php
@@ -4,7 +4,6 @@
  * @var array{collage: array} $config
  */
 
-use Photobooth\Enum\CollageLayoutEnum;
 use Photobooth\Service\LanguageService;
 use Photobooth\Collage;
 
@@ -33,10 +32,10 @@ function evaluateLayoutExpression(string $expr, float $x, float $y): float
 /**
  * Load collage layout from JSON file
  */
-function loadCollageLayoutFromJson(CollageLayoutEnum $layout, string $orientation = 'landscape'): ?array
+function loadCollageLayoutFromJson(string $layoutId, string $orientation = 'landscape'): ?array
 {
     // Get JSON path using Collage class method
-    $jsonPath = Collage::getCollageConfigPath($layout->value, $orientation);
+    $jsonPath = Collage::getCollageConfigPath($layoutId, $orientation);
 
     if (!$jsonPath || !file_exists($jsonPath)) {
         return null;
@@ -58,10 +57,12 @@ function loadCollageLayoutFromJson(CollageLayoutEnum $layout, string $orientatio
 /**
  * Generate SVG preview for collage layout (dynamically from JSON)
  */
-function getLayoutPreviewSvg(CollageLayoutEnum $layout, string $orientation = 'landscape'): string
+function getLayoutPreviewSvg(string $layoutId, string $orientation = 'landscape', ?array $layoutData = null): string
 {
     // Try to load layout from JSON
-    $layoutData = loadCollageLayoutFromJson($layout, $orientation);
+    if ($layoutData === null) {
+        $layoutData = loadCollageLayoutFromJson($layoutId, $orientation);
+    }
 
     if (!$layoutData) {
         // Fallback to simple 2x2 grid if JSON can't be loaded
@@ -82,14 +83,8 @@ function getLayoutPreviewSvg(CollageLayoutEnum $layout, string $orientation = 'l
         $scale = 0.1;
 
         // Check if this is a photostrip layout (2x4 or 2x3) where photos are duplicated
-        $isPhotostrip = in_array($layout, [
-            CollageLayoutEnum::TWO_X_FOUR_1,
-            CollageLayoutEnum::TWO_X_FOUR_2,
-            CollageLayoutEnum::TWO_X_FOUR_3,
-            CollageLayoutEnum::TWO_X_FOUR_4,
-            CollageLayoutEnum::TWO_X_THREE_1,
-            CollageLayoutEnum::TWO_X_THREE_2,
-        ]);
+        $layoutName = str_ends_with($layoutId, '.json') ? substr($layoutId, 0, -5) : $layoutId;
+        $isPhotostrip = str_starts_with($layoutName, '2x');
 
         // Calculate how many unique photos (half of total for photostrips)
         $layoutCount = count($layoutData['layout']);
@@ -217,7 +212,7 @@ function getLayoutPreviewSvg(CollageLayoutEnum $layout, string $orientation = 'l
     return $svg;
 }
 
-function renderCollageOptionsFromEnumWithLimit(array $collageConfig): string
+function renderCollageOptionsFromConfig(array $collageConfig): string
 {
     $languageService = LanguageService::getInstance();
 
@@ -231,23 +226,39 @@ function renderCollageOptionsFromEnumWithLimit(array $collageConfig): string
     // Get orientation from config (landscape or portrait)
     $orientation = $collageConfig['orientation'] ?? 'landscape';
 
-    foreach (CollageLayoutEnum::cases() as $layout) {
-        if (in_array($layout, $collageConfig['layouts_enabled'])) {
-            $collageConfig['layout'] = $layout->value;
-            $limitData = Collage::calculateLimit($collageConfig);
-            $limit = $limitData['limit'];
+    $layoutsEnabled = $collageConfig['layouts_enabled'] ?? [];
+    $layoutsEnabled = is_array($layoutsEnabled) ? $layoutsEnabled : [];
+    $layoutIds = [];
 
-            $html .= sprintf(
-                '<button type="button" class="collageSelector__option cursor-pointer" data-layout="%s" data-limit="%d">' .
-                '<div class="collageSelector__preview-container">%s</div>' .
-                '<div class="collageSelector__label">%s</div>' .
-                '</button>',
-                htmlspecialchars($layout->value),
-                $limit,
-                getLayoutPreviewSvg($layout, $orientation),
-                htmlspecialchars($layout->label())
-            );
+    foreach ($layoutsEnabled as $layoutValue) {
+        $layoutId = $layoutValue instanceof \BackedEnum ? (string) $layoutValue->value : (string) $layoutValue;
+        $layoutId = trim($layoutId);
+        if ($layoutId === '' || in_array($layoutId, $layoutIds, true)) {
+            continue;
         }
+        $layoutIds[] = $layoutId;
+    }
+
+    foreach ($layoutIds as $layoutId) {
+        $collageConfig['layout'] = $layoutId;
+        $limitData = Collage::calculateLimit($collageConfig);
+        $limit = $limitData['limit'];
+        $layoutData = loadCollageLayoutFromJson($layoutId, $orientation);
+        $label = $layoutId;
+        if (is_array($layoutData) && isset($layoutData['name']) && is_string($layoutData['name']) && $layoutData['name'] !== '') {
+            $label = $layoutData['name'];
+        }
+
+        $html .= sprintf(
+            '<button type="button" class="collageSelector__option cursor-pointer" data-layout="%s" data-limit="%d">' .
+            '<div class="collageSelector__preview-container">%s</div>' .
+            '<div class="collageSelector__label">%s</div>' .
+            '</button>',
+            htmlspecialchars($layoutId, ENT_QUOTES),
+            $limit,
+            getLayoutPreviewSvg($layoutId, $orientation, $layoutData),
+            htmlspecialchars($label, ENT_QUOTES)
+        );
     }
 
     $html .= '</div>'; // .collageSelector__options
@@ -265,4 +276,4 @@ function renderCollageOptionsFromEnumWithLimit(array $collageConfig): string
     return $html;
 }
 
-echo renderCollageOptionsFromEnumWithLimit($config['collage']);
+echo renderCollageOptionsFromConfig($config['collage']);

--- a/template/components/collageSelection.php
+++ b/template/components/collageSelection.php
@@ -161,15 +161,8 @@ function getLayoutPreviewSvg(string $layoutId, string $orientation = 'landscape'
         );
     }
 
-    // Add cut line for 2x4 and 2x3 layouts (shows where strip is cut)
-    if (
-        $layout === CollageLayoutEnum::TWO_X_FOUR_1 ||
-        $layout === CollageLayoutEnum::TWO_X_FOUR_2 ||
-        $layout === CollageLayoutEnum::TWO_X_FOUR_3 ||
-        $layout === CollageLayoutEnum::TWO_X_FOUR_4 ||
-        $layout === CollageLayoutEnum::TWO_X_THREE_1 ||
-        $layout === CollageLayoutEnum::TWO_X_THREE_2
-    ) {
+    // Add cut line for photostrip layouts (2x*)
+    if ($isPhotostrip) {
         // Dashed line in middle showing where it will be cut
         if ($width > $height) {
             // Landscape layout (e.g. 1800x1200) -> Horizontal cut


### PR DESCRIPTION
<!--
    Thank you for contributing!
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/PhotoboothProject/photobooth/blob/dev/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "x" next to an item)
<!-- Example:
- [x] Bug fix
-->

- [ ] Documentation update
- [ ] Bug fix
- [x] New feature
- [ ] Other, please explain:

<!--
    Please ensure your pull request is ready:

    - Please run 'npm run build' before submitting to have consistent formatting for both JavaScript & SCSS
    - Please run 'npm run eslint' to make sure there's no lint issues
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)
- Replaced the hardcoded collage layout list with dynamically loaded layouts defined as JSON files.
- Added a new API `getCollageLayouts.php` that scans
  `private/collage/layouts` and its `landscape` / `portrait` subdirectories and returns available layouts as `{ id, label }`.
- Updated the backend to treat layout IDs as free strings instead of fixed enums.
- Implemented a deterministic layout resolution and fallback order in `Collage.php`:
  1. `private/collage/layouts/<orientation>`
  2. `private/collage/layouts`
  3. legacy paths in `private/collage/*`
  4. `template/collage/*`
- Invalid or faulty private layout JSONs are ignored:
  - If a template layout with the same name exists, the template remains active.
  - If no template exists, the faulty private layout is not shown.
- Updated the admin GUI to load the layout list fully dynamically via the new API (no hardcoded layout array).
- The start screen layout selection now relies solely on string IDs stored in `layouts_enabled`; display names are taken from the `name` field in the layout JSON.

Tests:
- `npm run build`
- `npm run eslint`
- Verified dynamic discovery of layouts from all supported directories
- Confirmed new layouts appear in the admin UI immediately after adding a JSON file (after F5)
- Verified layout priority and fallback behavior across private, legacy, and template paths

#### Is there anything you'd like reviewers to focus on?

- Layout resolution priority/fallback in `src/Collage.php`
- Layout listing order/override behavior in `api/getCollageLayouts.php`
- Creation of the path not yet completed: `private/collage/layouts/landscape` and `private/collage/layouts/portrait`

#### AI used to create this Pull Request?
I used AI selectively in the code, for minor suggestions, alternatives or for understanding.
The idea, concept and logic behind the changes are my own.
