### PR TITLE
Apply text alignment regardless of allow_selection

### DIFF
--- a/src/Collage.php
+++ b/src/Collage.php
@@ -197,98 +197,96 @@ class Collage
                         $c->textOnCollageLinespace = isset($collageJson['text_linespace']) ? $collageJson['text_linespace'] : $c->textOnCollageLinespace;
                     }
 
-                    if ($c->collageAllowSelection) {
-                        // JSON layout can only disable or customize text if admin has enabled it
-                        if ($adminTextOnCollageEnabled === 'enabled') {
-                            if (isset($collageJson['text_disabled']) && $collageJson['text_disabled'] === true) {
-                                $c->textOnCollageEnabled = 'disabled';
-                            } elseif (isset($collageJson['text_alignment']) && is_array($collageJson['text_alignment'])) {
-                                $ta = $collageJson['text_alignment'];
-                                $c->textOnCollageEnabled = 'enabled';
+                    // JSON layout can only disable or customize text if admin has enabled it
+                    if ($adminTextOnCollageEnabled === 'enabled') {
+                        if ($c->collageAllowSelection && isset($collageJson['text_disabled']) && $collageJson['text_disabled'] === true) {
+                            $c->textOnCollageEnabled = 'disabled';
+                        } elseif (isset($collageJson['text_alignment']) && is_array($collageJson['text_alignment'])) {
+                            $ta = $collageJson['text_alignment'];
+                            $c->textOnCollageEnabled = 'enabled';
 
-                                $replace = ['x' => self::$collageWidth, 'y' => self::$collageHeight];
+                            $replace = ['x' => self::$collageWidth, 'y' => self::$collageHeight];
 
-                                // Check if zone mode
-                                if (isset($ta['mode']) && $ta['mode'] === 'zone') {
-                                    // Zone mode: store zone parameters for Image::applyTextInZone()
-                                    $c->textZoneMode = true;
-                                    $c->textZoneX = (float) Helper::doMath(str_replace(array_keys($replace), array_values($replace), $ta['x'] ?? '0'));
-                                    $c->textZoneY = (float) Helper::doMath(str_replace(array_keys($replace), array_values($replace), $ta['y'] ?? '0'));
-                                    $c->textZoneW = isset($ta['w']) ? (float) Helper::doMath(str_replace(array_keys($replace), array_values($replace), $ta['w'])) : 0;
-                                    $c->textZoneH = isset($ta['h']) ? (float) Helper::doMath(str_replace(array_keys($replace), array_values($replace), $ta['h'])) : 0;
-                                    $c->textZonePadding = isset($ta['padding']) ? (float) Helper::doMath(str_replace(array_keys($replace), array_values($replace), $ta['padding'])) : 0;
-                                    $c->textZoneAlign = $ta['align'] ?? 'center';
-                                    $c->textZoneValign = $ta['valign'] ?? 'middle';
-                                    $c->textZoneRotation = isset($ta['rotation']) ? (int) $ta['rotation'] : 0;
+                            // Check if zone mode
+                            if (isset($ta['mode']) && $ta['mode'] === 'zone') {
+                                // Zone mode: store zone parameters for Image::applyTextInZone()
+                                $c->textZoneMode = true;
+                                $c->textZoneX = (float) Helper::doMath(str_replace(array_keys($replace), array_values($replace), $ta['x'] ?? '0'));
+                                $c->textZoneY = (float) Helper::doMath(str_replace(array_keys($replace), array_values($replace), $ta['y'] ?? '0'));
+                                $c->textZoneW = isset($ta['w']) ? (float) Helper::doMath(str_replace(array_keys($replace), array_values($replace), $ta['w'])) : 0;
+                                $c->textZoneH = isset($ta['h']) ? (float) Helper::doMath(str_replace(array_keys($replace), array_values($replace), $ta['h'])) : 0;
+                                $c->textZonePadding = isset($ta['padding']) ? (float) Helper::doMath(str_replace(array_keys($replace), array_values($replace), $ta['padding'])) : 0;
+                                $c->textZoneAlign = $ta['align'] ?? 'center';
+                                $c->textZoneValign = $ta['valign'] ?? 'middle';
+                                $c->textZoneRotation = isset($ta['rotation']) ? (int) $ta['rotation'] : 0;
 
-                                    // In zone mode: ignore admin X/Y/Rotation values
-                                    // Keep admin font, color, text lines, fontSize (as start), lineHeight (as factor)
-                                } else {
-                                    // Legacy mode: calculate X/Y position based on alignment
-                                    $zoneX = Helper::doMath(str_replace(array_keys($replace), array_values($replace), $ta['x'] ?? '0'));
-                                    $zoneY = Helper::doMath(str_replace(array_keys($replace), array_values($replace), $ta['y'] ?? '0'));
-                                    $zoneW = isset($ta['w']) ? Helper::doMath(str_replace(array_keys($replace), array_values($replace), $ta['w'])) : 0;
-                                    $zoneH = isset($ta['h']) ? Helper::doMath(str_replace(array_keys($replace), array_values($replace), $ta['h'])) : 0;
+                                // In zone mode: ignore admin X/Y/Rotation values
+                                // Keep admin font, color, text lines, fontSize (as start), lineHeight (as factor)
+                            } else {
+                                // Legacy mode: calculate X/Y position based on alignment
+                                $zoneX = Helper::doMath(str_replace(array_keys($replace), array_values($replace), $ta['x'] ?? '0'));
+                                $zoneY = Helper::doMath(str_replace(array_keys($replace), array_values($replace), $ta['y'] ?? '0'));
+                                $zoneW = isset($ta['w']) ? Helper::doMath(str_replace(array_keys($replace), array_values($replace), $ta['w'])) : 0;
+                                $zoneH = isset($ta['h']) ? Helper::doMath(str_replace(array_keys($replace), array_values($replace), $ta['h'])) : 0;
 
-                                    if (isset($ta['fontSize'])) {
-                                        $c->textOnCollageFontSize = (int) Helper::doMath(str_replace(array_keys($replace), array_values($replace), $ta['fontSize']));
+                                if (isset($ta['fontSize'])) {
+                                    $c->textOnCollageFontSize = (int) Helper::doMath(str_replace(array_keys($replace), array_values($replace), $ta['fontSize']));
+                                }
+
+                                if (isset($ta['rotation'])) {
+                                    $c->textOnCollageRotation = (int) $ta['rotation'];
+                                }
+
+                                if (isset($ta['lineHeight'])) {
+                                    $c->textOnCollageLinespace = (int) Helper::doMath(str_replace(array_keys($replace), array_values($replace), $ta['lineHeight']));
+                                }
+
+                                $align = $ta['align'] ?? 'start';
+                                $valign = $ta['valign'] ?? 'top';
+
+                                if ($align === 'center' || $valign === 'middle') {
+                                    $textLines = [];
+                                    if (!empty($c->textOnCollageLine1)) {
+                                        $textLines[] = $c->textOnCollageLine1;
+                                    }
+                                    if (!empty($c->textOnCollageLine2)) {
+                                        $textLines[] = $c->textOnCollageLine2;
+                                    }
+                                    if (!empty($c->textOnCollageLine3)) {
+                                        $textLines[] = $c->textOnCollageLine3;
                                     }
 
-                                    if (isset($ta['rotation'])) {
-                                        $c->textOnCollageRotation = (int) $ta['rotation'];
-                                    }
-
-                                    if (isset($ta['lineHeight'])) {
-                                        $c->textOnCollageLinespace = (int) Helper::doMath(str_replace(array_keys($replace), array_values($replace), $ta['lineHeight']));
-                                    }
-
-                                    $align = $ta['align'] ?? 'start';
-                                    $valign = $ta['valign'] ?? 'top';
-
-                                    if ($align === 'center' || $valign === 'middle') {
-                                        $textLines = [];
-                                        if (!empty($c->textOnCollageLine1)) {
-                                            $textLines[] = $c->textOnCollageLine1;
-                                        }
-                                        if (!empty($c->textOnCollageLine2)) {
-                                            $textLines[] = $c->textOnCollageLine2;
-                                        }
-                                        if (!empty($c->textOnCollageLine3)) {
-                                            $textLines[] = $c->textOnCollageLine3;
-                                        }
-
-                                        if (count($textLines) > 0 && file_exists($c->textOnCollageFont)) {
-                                            $maxWidth = 0;
-                                            foreach ($textLines as $line) {
-                                                $bbox = imagettfbbox($c->textOnCollageFontSize, $c->textOnCollageRotation, $c->textOnCollageFont, $line);
-                                                if ($bbox) {
-                                                    $width = abs($bbox[2] - $bbox[0]);
-                                                    if ($width > $maxWidth) {
-                                                        $maxWidth = $width;
-                                                    }
+                                    if (count($textLines) > 0 && file_exists($c->textOnCollageFont)) {
+                                        $maxWidth = 0;
+                                        foreach ($textLines as $line) {
+                                            $bbox = imagettfbbox($c->textOnCollageFontSize, $c->textOnCollageRotation, $c->textOnCollageFont, $line);
+                                            if ($bbox) {
+                                                $width = abs($bbox[2] - $bbox[0]);
+                                                if ($width > $maxWidth) {
+                                                    $maxWidth = $width;
                                                 }
                                             }
-                                            $totalHeight = $c->textOnCollageFontSize + (count($textLines) - 1) * $c->textOnCollageLinespace;
+                                        }
+                                        $totalHeight = $c->textOnCollageFontSize + (count($textLines) - 1) * $c->textOnCollageLinespace;
 
-                                            if ($align === 'center') {
-                                                $c->textOnCollageLocationX = (int) ($zoneX + ($zoneW - $maxWidth) / 2);
-                                            } else {
-                                                $c->textOnCollageLocationX = (int) $zoneX;
-                                            }
-
-                                            if ($valign === 'middle') {
-                                                $c->textOnCollageLocationY = (int) ($zoneY + ($zoneH - $totalHeight) / 2 + $c->textOnCollageFontSize);
-                                            } else {
-                                                $c->textOnCollageLocationY = (int) ($zoneY + $c->textOnCollageFontSize);
-                                            }
+                                        if ($align === 'center') {
+                                            $c->textOnCollageLocationX = (int) ($zoneX + ($zoneW - $maxWidth) / 2);
                                         } else {
                                             $c->textOnCollageLocationX = (int) $zoneX;
-                                            $c->textOnCollageLocationY = (int) $zoneY;
+                                        }
+
+                                        if ($valign === 'middle') {
+                                            $c->textOnCollageLocationY = (int) ($zoneY + ($zoneH - $totalHeight) / 2 + $c->textOnCollageFontSize);
+                                        } else {
+                                            $c->textOnCollageLocationY = (int) ($zoneY + $c->textOnCollageFontSize);
                                         }
                                     } else {
                                         $c->textOnCollageLocationX = (int) $zoneX;
                                         $c->textOnCollageLocationY = (int) $zoneY;
                                     }
+                                } else {
+                                    $c->textOnCollageLocationX = (int) $zoneX;
+                                    $c->textOnCollageLocationY = (int) $zoneY;
                                 }
                             }
                         }


### PR DESCRIPTION
<!--
    Thank you for contributing!
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/PhotoboothProject/photobooth/blob/dev/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "x" next to an item)
<!-- Example:
- [x] Bug fix
-->

- [ ] Documentation update
- [x] Bug fix https://github.com/PhotoboothProject/photobooth/issues/1433
- [ ] New feature
- [ ] Other, please explain:

<!--
    Please ensure your pull request is ready:

    - Please run 'npm run build' before submitting to have consistent formatting for both JavaScript & SCSS
    - Please run 'npm run eslint' to make sure there's no lint issues
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)
- Apply `text_alignment` from layout JSON even when `collage.allow_selection` is disabled.
- Keep `text_disabled` behavior tied to `allow_selection` to avoid unexpected text hiding.

#### Is there anything you'd like reviewers to focus on?
- Whether `text_alignment` should be independent of `allow_selection`.
- Whether keeping `text_disabled` behind `allow_selection` matches expected behavior.
- When `text_alignment` is defined in the layout JSON, admin-side text position settings no longer override it. Please confirm this is the intended behavior; if not, we may need an explicit override option in the UI.

<!--#### AI used to create this Pull Request?

If AI was used to create this Pull Request please tell about the impact to submitted changes in detail.
-->
