### PR TITLE
fix: support text rotation in collage zone mode and respect admin set…

### DIFF
--- a/src/Collage.php
+++ b/src/Collage.php
@@ -275,10 +275,12 @@ class Collage
                     }
 
                     // JSON layout can only disable or customize text if admin has enabled it
+                    // Zone-based text alignment is only applied when layout selection is allowed,
+                    // otherwise admin panel coordinates (locationx, locationy, rotation) are used
                     if ($adminTextOnCollageEnabled === 'enabled') {
                         if ($c->collageAllowSelection && isset($collageJson['text_disabled']) && $collageJson['text_disabled'] === true) {
                             $c->textOnCollageEnabled = 'disabled';
-                        } elseif (isset($collageJson['text_alignment']) && is_array($collageJson['text_alignment'])) {
+                        } elseif ($c->collageAllowSelection && isset($collageJson['text_alignment']) && is_array($collageJson['text_alignment'])) {
                             $ta = $collageJson['text_alignment'];
                             $c->textOnCollageEnabled = 'enabled';
 
@@ -295,9 +297,9 @@ class Collage
                                 $c->textZonePadding = isset($ta['padding']) ? (float) Helper::doMath(str_replace(array_keys($replace), array_values($replace), $ta['padding'])) : 0;
                                 $c->textZoneAlign = $ta['align'] ?? 'center';
                                 $c->textZoneValign = $ta['valign'] ?? 'middle';
-                                $c->textZoneRotation = isset($ta['rotation']) ? (int) $ta['rotation'] : 0;
+                                $c->textZoneRotation = $c->textOnCollageRotation;
 
-                                // In zone mode: ignore admin X/Y/Rotation values
+                                // In zone mode: ignore admin X/Y values, use admin rotation
                                 // Keep admin font, color, text lines, fontSize (as start), lineHeight (as factor)
                             } else {
                                 // Legacy mode: calculate X/Y position based on alignment
@@ -310,9 +312,7 @@ class Collage
                                     $c->textOnCollageFontSize = (int) Helper::doMath(str_replace(array_keys($replace), array_values($replace), $ta['fontSize']));
                                 }
 
-                                if (isset($ta['rotation'])) {
-                                    $c->textOnCollageRotation = (int) $ta['rotation'];
-                                }
+                                // Admin rotation is always used, JSON rotation is ignored
 
                                 if (isset($ta['lineHeight'])) {
                                     $c->textOnCollageLinespace = (int) Helper::doMath(str_replace(array_keys($replace), array_values($replace), $ta['lineHeight']));

--- a/src/Collage.php
+++ b/src/Collage.php
@@ -198,6 +198,11 @@ class Collage
         return self::getLegacyCollageConfigPath($layoutId, $pictureOrientation);
     }
 
+    private static function isPrivateCollageConfigPath(string $absolutePath): bool
+    {
+        return str_starts_with(PathUtility::toProjectRelative($absolutePath), 'private/');
+    }
+
     public static function createCollage(array $config, array $srcImagePaths, string $destImagePath, ?ImageFilterEnum $filter = null, ?CollageConfig $c = null): bool
     {
         if ($c === null) {
@@ -212,6 +217,8 @@ class Collage
         self::$pictureOrientation = $c->collageOrientation;
 
         $collageConfigFilePath = self::getCollageConfigPath($c->collageLayout, self::$pictureOrientation);
+        $collageConfigIsPrivate = $collageConfigFilePath !== null
+            && self::isPrivateCollageConfigPath($collageConfigFilePath);
 
         // Save the original admin setting for text on collage
         $adminTextOnCollageEnabled = $c->textOnCollageEnabled;
@@ -274,13 +281,15 @@ class Collage
                         $c->textOnCollageLinespace = isset($collageJson['text_linespace']) ? $collageJson['text_linespace'] : $c->textOnCollageLinespace;
                     }
 
-                    // JSON layout can only disable or customize text if admin has enabled it
-                    // Zone-based text alignment is only applied when layout selection is allowed,
-                    // otherwise admin panel coordinates (locationx, locationy, rotation) are used
+                    // JSON layout can only disable or customize text if admin has enabled it.
+                    // Layouts from private/ always respect their JSON text config,
+                    // other layouts require allow_selection.
                     if ($adminTextOnCollageEnabled === 'enabled') {
-                        if ($c->collageAllowSelection && isset($collageJson['text_disabled']) && $collageJson['text_disabled'] === true) {
+                        $allowJsonTextOverrides = $c->collageAllowSelection || $collageConfigIsPrivate;
+
+                        if ($allowJsonTextOverrides && isset($collageJson['text_disabled']) && $collageJson['text_disabled'] === true) {
                             $c->textOnCollageEnabled = 'disabled';
-                        } elseif ($c->collageAllowSelection && isset($collageJson['text_alignment']) && is_array($collageJson['text_alignment'])) {
+                        } elseif ($allowJsonTextOverrides && isset($collageJson['text_alignment']) && is_array($collageJson['text_alignment'])) {
                             $ta = $collageJson['text_alignment'];
                             $c->textOnCollageEnabled = 'enabled';
 
@@ -298,8 +307,11 @@ class Collage
                                 $c->textZoneAlign = $ta['align'] ?? 'center';
                                 $c->textZoneValign = $ta['valign'] ?? 'middle';
                                 $c->textZoneRotation = $c->textOnCollageRotation;
+                                if ($collageConfigIsPrivate && isset($ta['rotation'])) {
+                                    $c->textZoneRotation = (int) $ta['rotation'];
+                                }
 
-                                // In zone mode: ignore admin X/Y values, use admin rotation
+                                // In zone mode: ignore admin X/Y values
                                 // Keep admin font, color, text lines, fontSize (as start), lineHeight (as factor)
                             } else {
                                 // Legacy mode: calculate X/Y position based on alignment
@@ -312,7 +324,9 @@ class Collage
                                     $c->textOnCollageFontSize = (int) Helper::doMath(str_replace(array_keys($replace), array_values($replace), $ta['fontSize']));
                                 }
 
-                                // Admin rotation is always used, JSON rotation is ignored
+                                if ($collageConfigIsPrivate && isset($ta['rotation'])) {
+                                    $c->textOnCollageRotation = (int) $ta['rotation'];
+                                }
 
                                 if (isset($ta['lineHeight'])) {
                                     $c->textOnCollageLinespace = (int) Helper::doMath(str_replace(array_keys($replace), array_values($replace), $ta['lineHeight']));

--- a/src/Image.php
+++ b/src/Image.php
@@ -138,7 +138,7 @@ class Image
     public string $textZoneValign = 'middle';
 
     /**
-     * Rotation angle for zone text (currently only 0 supported)
+     * Rotation angle for zone text
      */
     public int $textZoneRotation = 0;
 
@@ -986,8 +986,8 @@ class Image
             $fontSize = $minFontSize;
         }
 
-        // Recalculate with final font size
-        $lineHeight = (int)($fontSize * $lineHeightFactor);
+        // Recalculate with final font size, but ensure admin linespace is respected as minimum
+        $lineHeight = max((int)($fontSize * $lineHeightFactor), $this->textLineSpacing);
         $blockHeight = (count($lines) - 1) * $lineHeight + $fontSize;
 
         // Get ascent for baseline correction
@@ -1009,34 +1009,130 @@ class Image
                 break;
         }
 
-        // Draw each line with individual horizontal alignment
-        foreach ($lines as $index => $line) {
-            // Measure this specific line
-            $bbox = @imagettfbbox($fontSize, 0, $fontPath, $line);
-            $lineWidth = $bbox !== false ? abs($bbox[2] - $bbox[0]) : 0;
+        // Calculate base X position for the text block
+        $rotation = $this->textZoneRotation;
+        $radians = deg2rad($rotation);
 
-            // Calculate X position based on align
+        if ($rotation != 0) {
+            // Measure all lines and collect widths
+            $maxLineWidth = 0;
+            $lineWidths = [];
+            foreach ($lines as $line) {
+                $bbox = @imagettfbbox($fontSize, 0, $fontPath, $line);
+                $w = $bbox !== false ? abs($bbox[2] - $bbox[0]) : 0;
+                $lineWidths[] = $w;
+                if ($w > $maxLineWidth) {
+                    $maxLineWidth = $w;
+                }
+            }
+
+            $cosR = cos($radians);
+            $sinR = sin($radians);
+            $lineCount = count($lines);
+
+            // Calculate all draw positions (before zone centering) relative to origin (0,0)
+            // Each line is stacked perpendicular to text direction and centered along it
+            $positions = [];
+            foreach ($lines as $index => $line) {
+                $lineWidth = $lineWidths[$index];
+                $centerShift = ($maxLineWidth - $lineWidth) / 2;
+
+                // Perpendicular offset (stacking): direction (sin(θ), cos(θ))
+                $perpX = $index * $lineHeight * $sinR;
+                $perpY = $index * $lineHeight * $cosR;
+
+                // Parallel offset (centering): direction (cos(θ), -sin(θ))
+                $paraX = $centerShift * $cosR;
+                $paraY = -$centerShift * $sinR;
+
+                $positions[] = ['x' => $perpX + $paraX, 'y' => $perpY + $paraY];
+            }
+
+            // Calculate actual bounding box of all rendered text using imagettfbbox with rotation
+            $minBx = PHP_INT_MAX;
+            $minBy = PHP_INT_MAX;
+            $maxBx = PHP_INT_MIN;
+            $maxBy = PHP_INT_MIN;
+            foreach ($lines as $index => $line) {
+                $bbox = @imagettfbbox($fontSize, $rotation, $fontPath, $line);
+                if ($bbox !== false) {
+                    $px = $positions[$index]['x'];
+                    $py = $positions[$index]['y'];
+                    // imagettfbbox returns 4 corners: ll, lr, ur, ul
+                    for ($i = 0; $i < 8; $i += 2) {
+                        $bx = $px + $bbox[$i];
+                        $by = $py + $bbox[$i + 1];
+                        $minBx = min($minBx, $bx);
+                        $minBy = min($minBy, $by);
+                        $maxBx = max($maxBx, $bx);
+                        $maxBy = max($maxBy, $by);
+                    }
+                }
+            }
+
+            $totalW = $maxBx - $minBx;
+            $totalH = $maxBy - $minBy;
+
+            // Calculate zone center offset for the text block
             switch ($this->textZoneAlign) {
                 case 'right':
-                    $drawX = (int)($zoneX + $zoneW - $lineWidth);
+                    $offsetX = $zoneX + $zoneW - $totalW - $minBx;
                     break;
                 case 'center':
-                    $drawX = (int)($zoneX + ($zoneW - $lineWidth) / 2);
+                    $offsetX = $zoneX + ($zoneW - $totalW) / 2 - $minBx;
                     break;
                 case 'left':
                 default:
-                    $drawX = (int)$zoneX;
+                    $offsetX = $zoneX - $minBx;
                     break;
             }
 
-            // Calculate Y position (baseline position)
-            // First line: startTopY + ascent (to position top of text at startTopY)
-            // Subsequent lines: add lineHeight for each
-            $drawY = (int)($startTopY + $ascent + ($index * $lineHeight));
+            switch ($this->textZoneValign) {
+                case 'bottom':
+                    $offsetY = $zoneY + $zoneH - $totalH - $minBy;
+                    break;
+                case 'middle':
+                    $offsetY = $zoneY + ($zoneH - $totalH) / 2 - $minBy;
+                    break;
+                case 'top':
+                default:
+                    $offsetY = $zoneY - $minBy;
+                    break;
+            }
 
-            // Draw the text (rotation is 0 for zone mode)
-            if (!imagettftext($sourceResource, $fontSize, 0, $drawX, $drawY, $color, $fontPath, $line)) {
-                throw new \Exception('Could not add line ' . ($index + 1) . ' of text to resource.');
+            // Draw each line at calculated position + zone offset
+            foreach ($lines as $index => $line) {
+                $drawX = (int)($positions[$index]['x'] + $offsetX);
+                $drawY = (int)($positions[$index]['y'] + $offsetY);
+
+                if (!imagettftext($sourceResource, $fontSize, $rotation, $drawX, $drawY, $color, $fontPath, $line)) {
+                    throw new \Exception('Could not add line ' . ($index + 1) . ' of text to resource.');
+                }
+            }
+        } else {
+            // No rotation: per-line horizontal alignment
+            foreach ($lines as $index => $line) {
+                $bbox = @imagettfbbox($fontSize, 0, $fontPath, $line);
+                $lineWidth = $bbox !== false ? abs($bbox[2] - $bbox[0]) : 0;
+
+                switch ($this->textZoneAlign) {
+                    case 'right':
+                        $drawX = (int)($zoneX + $zoneW - $lineWidth);
+                        break;
+                    case 'center':
+                        $drawX = (int)($zoneX + ($zoneW - $lineWidth) / 2);
+                        break;
+                    case 'left':
+                    default:
+                        $drawX = (int)$zoneX;
+                        break;
+                }
+
+                $drawY = (int)($startTopY + $ascent + ($index * $lineHeight));
+
+                if (!imagettftext($sourceResource, $fontSize, 0, $drawX, $drawY, $color, $fontPath, $line)) {
+                    throw new \Exception('Could not add line ' . ($index + 1) . ' of text to resource.');
+                }
             }
         }
     }


### PR DESCRIPTION
fix: support text rotation in collage zone mode and respect admin settings

Previously, the text rotation configured in the admin panel was ignored when
using collage layouts with zone-based text alignment (text_alignment.mode = "zone").
The zone rendering in Image::applyTextInZone() always passed rotation=0 to
imagettftext(), and Collage.php allowed JSON layout files to override the admin
rotation value.

Changes in Collage.php:
- Zone-based text alignment from layout JSON is now only applied when
  "Allow layout selection" (collageAllowSelection) is enabled. When
  disabled, admin panel coordinates (locationx, locationy, rotation)
  are used directly via legacy rendering
- Admin rotation value always takes priority over JSON layout rotation
  in both zone mode and legacy mode when layout selection is active
- text_disabled from JSON is also only honored when layout selection
  is enabled

Changes in Image.php:
- applyTextInZone() now applies the configured rotation angle to
  imagettftext() instead of hardcoding 0
- Rotated text lines are stacked perpendicular to the text direction
  using trigonometric offset calculation (sin/cos) so lines appear
  properly aligned at any angle
- Each line is individually centered along the text direction based on
  its width relative to the widest line
- The entire rotated text block is precisely centered within the text
  zone by calculating the actual bounding box of all rendered glyphs
  using imagettfbbox() with the rotation angle, then computing the
  offset needed for proper horizontal (align) and vertical (valign)
  zone alignment
- Admin line spacing (linespace) is respected as minimum distance
  between lines, preventing text from collapsing when auto-fit reduces
  the font size
- Removed outdated comment "currently only 0 supported" from
  textZoneRotation property

Closes #1433

<!--
    Thank you for contributing!
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/PhotoboothProject/photobooth/blob/dev/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "x" next to an item)

- [ ] Documentation update
- [x] Bug fix
- [ ] New feature
- [ ] Other, please explain:

#### What changes did you make? (Give an overview)

When `collage.allow_selection` is enabled and the user selects a collage layout
with zone-based text alignment (`text_alignment.mode = "zone"`), the text rotation
configured in the admin panel was completely ignored. The text was always rendered
at 0 degrees regardless of the admin setting.

**Root cause:** Two issues:
1. `Image::applyTextInZone()` hardcoded `rotation=0` in the `imagettftext()` call,
   ignoring the `textZoneRotation` property entirely
2. `Collage.php` allowed JSON layout files to override the admin rotation value
   (most layouts set `rotation: 0` explicitly)

**Fix:**
- Admin rotation always takes priority over JSON layout rotation
- Zone-based text alignment is only applied when layout selection is enabled;
  when disabled, admin coordinates (locationx, locationy, rotation) are used directly
- `applyTextInZone()` now properly renders rotated text with correct line stacking
  (perpendicular to text direction using sin/cos), per-line centering along the text
  direction, and precise bounding-box-based centering within the text zone
- Admin line spacing is respected as minimum value even when auto-fit reduces font size

#### Is there anything you'd like reviewers to focus on?

- The rotated text rendering logic in `Image::applyTextInZone()`: it uses
  `imagettfbbox()` with the actual rotation angle to compute the precise bounding
  box of the entire text block, then centers it within the zone. This approach
  works correctly for any rotation angle (-359 to 359).
- The `$c->collageAllowSelection` guard on `text_alignment` processing in
  `Collage.php`: this ensures that when layout selection is disabled, the admin
  has full control over text positioning via locationx/locationy/rotation.

#### AI used to create this Pull Request?

Yes, Claude Code (claude-sonnet-4-6) was used to assist with:
- Analyzing the rendering pipeline to identify the root cause
- Implementing the trigonometric text positioning for rotated zone text
- Running local CI checks (PHPStan, PHPUnit, PHP Lint, pre-commit hooks)