### PR TITLE
bugfix/csrf

### DIFF
--- a/api/csrf.php
+++ b/api/csrf.php
@@ -1,0 +1,14 @@
+<?php
+
+require_once '../lib/boot.php';
+
+header('Content-Type: application/json');
+header('Cache-Control: no-store, no-cache, must-revalidate, max-age=0');
+header('Pragma: no-cache');
+
+echo json_encode([
+    'key' => 'csrf',
+    'token' => $_SESSION['csrf'] ?? '',
+]);
+
+exit();

--- a/assets/js/admin/index.js
+++ b/assets/js/admin/index.js
@@ -1,4 +1,4 @@
-/* globals photoboothTools csrf */
+/* globals photoboothTools */
 /* eslint-env browser */
 $(function () {
     initDirtyTracking();
@@ -288,19 +288,24 @@ const shellCommand = function ($mode, $filename = '') {
         mode: $mode,
         filename: $filename
     };
-    if (typeof csrf !== 'undefined') {
-        command[csrf.key] = csrf.token;
-    }
 
     photoboothTools.console.log('Run' + $mode);
 
-    jQuery
-        .post('../api/shellCommand.php', command)
+    photoboothTools
+        .ajaxWithCsrf({
+            url: '../api/shellCommand.php',
+            method: 'POST',
+            data: command
+        })
         .done(function (result) {
             photoboothTools.console.log($mode, 'result: ', result);
         })
-        .fail(function (xhr, status, result) {
-            photoboothTools.console.log($mode, 'result: ', result);
+        .fail(function (xhr, status, errorThrown) {
+            if (photoboothTools.isCsrfErrorResponse(xhr)) {
+                photoboothTools.handleCsrfMismatch('../api/shellCommand.php');
+                return;
+            }
+            photoboothTools.console.log($mode, 'result: ', errorThrown);
         });
 };
 

--- a/assets/js/core.js
+++ b/assets/js/core.js
@@ -471,19 +471,23 @@ const photoBooth = (function () {
             mode: cmd,
             filename: file
         };
-        if (typeof csrf !== 'undefined') {
-            command[csrf.key] = csrf.token;
-        }
-
         photoboothTools.console.log('Run', cmd);
 
-        jQuery
-            .post(environment.publicFolders.api + '/shellCommand.php', command)
+        photoboothTools
+            .ajaxWithCsrf({
+                url: environment.publicFolders.api + '/shellCommand.php',
+                method: 'POST',
+                data: command
+            })
             .done(function (result) {
                 photoboothTools.console.log(cmd, 'result: ', result);
             })
-            .fail(function (xhr, status, result) {
-                photoboothTools.console.log(cmd, 'result: ', result);
+            .fail(function (xhr, status, errorThrown) {
+                if (photoboothTools.isCsrfErrorResponse(xhr)) {
+                    photoboothTools.handleCsrfMismatch(environment.publicFolders.api + '/shellCommand.php');
+                    return;
+                }
+                photoboothTools.console.log(cmd, 'result: ', errorThrown);
             });
     };
 
@@ -668,9 +672,10 @@ const photoBooth = (function () {
     api.callTakePicApi = async (data, retry = 0) => {
         startTime = new Date().getTime();
         photoboothTools.console.logDev('Capture image.');
-        jQuery
-            .post({
+        photoboothTools
+            .ajaxWithCsrf({
                 url: environment.publicFolders.api + '/capture.php',
+                method: 'POST',
                 data: data,
                 timeout: 25000
             })
@@ -836,6 +841,10 @@ const photoBooth = (function () {
             })
             .fail(async (xhr, status, result) => {
                 try {
+                    if (photoboothTools.isCsrfErrorResponse(xhr)) {
+                        photoboothTools.handleCsrfMismatch(environment.publicFolders.api + '/capture.php');
+                        return;
+                    }
                     endTime = new Date().getTime();
                     totalTime = endTime - startTime;
                     api.cheese.destroy();
@@ -869,9 +878,10 @@ const photoBooth = (function () {
             videoAnimation.show();
         }
         startTime = new Date().getTime();
-        jQuery
-            .post({
+        photoboothTools
+            .ajaxWithCsrf({
                 url: environment.publicFolders.api + '/capture.php',
+                method: 'POST',
                 data: data,
                 timeout: 25000
             })
@@ -901,6 +911,10 @@ const photoBooth = (function () {
             })
             .fail(function (xhr, status, result) {
                 try {
+                    if (photoboothTools.isCsrfErrorResponse(xhr)) {
+                        photoboothTools.handleCsrfMismatch(environment.publicFolders.api + '/capture.php');
+                        return;
+                    }
                     api.cheese.destroy();
                     if (result === null || result === undefined || typeof result === 'string') {
                         result = { error: result || 'Unexpected error: result is null or undefined' };
@@ -995,17 +1009,19 @@ const photoBooth = (function () {
             preloadImage.src = tempImageUrl;
         }
 
-        $.ajax({
-            method: 'POST',
-            url: environment.publicFolders.api + '/applyEffects.php',
-            data: {
-                file: result.file,
-                filter: imgFilter,
-                style: api.photoStyle,
-                collageLayout: api.collageLayout,
-                collageLimit: api.collageLimit
-            },
-            success: (data) => {
+        photoboothTools
+            .ajaxWithCsrf({
+                method: 'POST',
+                url: environment.publicFolders.api + '/applyEffects.php',
+                data: {
+                    file: result.file,
+                    filter: imgFilter,
+                    style: api.photoStyle,
+                    collageLayout: api.collageLayout,
+                    collageLimit: api.collageLimit
+                }
+            })
+            .done((data) => {
                 try {
                     setFiltersEnabled(true);
                     photoboothTools.console.log(api.photoStyle + ' processed', data);
@@ -1032,14 +1048,17 @@ const photoBooth = (function () {
                     photoboothTools.console.log('processPic.success: unexpected error:', error);
                     api.errorPic({ error: error.message || 'Unexpected error processing picture' });
                 }
-            },
-            error: (jqXHR, textStatus) => {
+            })
+            .fail((jqXHR, textStatus) => {
+                if (photoboothTools.isCsrfErrorResponse(jqXHR)) {
+                    photoboothTools.handleCsrfMismatch(environment.publicFolders.api + '/applyEffects.php');
+                    return;
+                }
                 setFiltersEnabled(true);
                 api.errorPic({
                     error: 'Request failed: ' + textStatus
                 });
-            }
-        });
+            });
     };
 
     api.processVideo = function (result) {
@@ -1053,13 +1072,15 @@ const photoBooth = (function () {
             '<i class="' + config.icons.spinner + '"></i><br>' + photoboothTools.getTranslation('busyVideo')
         );
 
-        $.ajax({
-            method: 'POST',
-            url: environment.publicFolders.api + '/applyVideoEffects.php',
-            data: {
-                file: result.file
-            },
-            success: (data) => {
+        photoboothTools
+            .ajaxWithCsrf({
+                method: 'POST',
+                url: environment.publicFolders.api + '/applyVideoEffects.php',
+                data: {
+                    file: result.file
+                }
+            })
+            .done((data) => {
                 try {
                     photoboothTools.console.log('video processed', data);
                     endTime = new Date().getTime();
@@ -1104,13 +1125,16 @@ const photoBooth = (function () {
                     photoboothTools.console.log('processVideo.success: unexpected error:', error);
                     api.errorPic({ error: error.message || 'Unexpected error processing video' });
                 }
-            },
-            error: (jqXHR, textStatus) => {
+            })
+            .fail((jqXHR, textStatus) => {
+                if (photoboothTools.isCsrfErrorResponse(jqXHR)) {
+                    photoboothTools.handleCsrfMismatch(environment.publicFolders.api + '/applyVideoEffects.php');
+                    return;
+                }
                 api.errorPic({
                     error: 'Request failed: ' + textStatus
                 });
-            }
-        });
+            });
     };
 
     api.renderChroma = function (filename) {

--- a/assets/js/preview.js
+++ b/assets/js/preview.js
@@ -1,6 +1,6 @@
 /* eslint n/no-unsupported-features/node-builtins: "off" */
 
-/* globals photoBooth photoboothTools csrf */
+/* globals photoBooth photoboothTools */
 
 function getPreviewUrlWithCacheBusting() {
     const url = getBasePreviewUrl();
@@ -147,18 +147,25 @@ const photoboothPreview = (function () {
     api.runCmd = function (mode) {
         const dataVideo = {
             play: mode,
-            pid: pid,
-            [csrf.key]: csrf.token
+            pid: pid
         };
 
-        jQuery
-            .post('api/previewCamera.php', dataVideo)
+        photoboothTools
+            .ajaxWithCsrf({
+                url: 'api/previewCamera.php',
+                method: 'POST',
+                data: dataVideo
+            })
             .done(function (result) {
                 photoboothTools.console.log('Preview: ' + dataVideo.play + ' webcam successfully.');
                 pid = result.pid;
             })
             // eslint-disable-next-line no-unused-vars
             .fail(function (xhr, status, result) {
+                if (photoboothTools.isCsrfErrorResponse(xhr)) {
+                    photoboothTools.handleCsrfMismatch('api/previewCamera.php');
+                    return;
+                }
                 photoboothTools.console.log('ERROR: Preview: Failed to ' + dataVideo.play + ' webcam!');
             });
     };

--- a/assets/js/tools.js
+++ b/assets/js/tools.js
@@ -165,8 +165,8 @@ const photoboothTools = (function () {
         }
 
         api.csrfReloadScheduled = true;
-        const message = 'Session expired. Reloading...';
-        api.console.log('CSRF mismatch detected.', context);
+        const message = api.getTranslation('csrf_session_reloading');
+        api.console.log('ERROR: CSRF token mismatch', context);
         api.overlay.showWarning(message);
         setTimeout(() => {
             api.reloadPage();

--- a/assets/js/tools.js
+++ b/assets/js/tools.js
@@ -8,9 +8,75 @@ const photoboothTools = (function () {
     api.translations = null;
     api.sounds = null;
     api.isPrinting = false;
+    api.csrfRefreshPromise = null;
+    api.csrfReloadScheduled = false;
+
+    api.hasCsrf = function () {
+        return typeof csrf !== 'undefined' && typeof csrf.key === 'string' && typeof csrf.token === 'string';
+    };
+
+    api.getCsrfErrorMessage = function () {
+        return 'Invalid CSRF token';
+    };
+
+    api.isCsrfErrorText = function (text) {
+        if (typeof text !== 'string' || text === '') {
+            return false;
+        }
+
+        return text.toLowerCase().includes(api.getCsrfErrorMessage().toLowerCase());
+    };
+
+    api.extractErrorMessage = function (payload) {
+        if (!payload) {
+            return '';
+        }
+
+        if (typeof payload === 'string') {
+            return payload;
+        }
+
+        if (typeof payload.error === 'string') {
+            return payload.error;
+        }
+
+        return '';
+    };
+
+    api.isCsrfErrorResponse = function (xhr) {
+        if (!xhr || xhr.status !== 403) {
+            return false;
+        }
+
+        const jsonMessage = api.extractErrorMessage(xhr.responseJSON);
+        const textMessage = typeof xhr.responseText === 'string' ? xhr.responseText : '';
+
+        return api.isCsrfErrorText(jsonMessage) || api.isCsrfErrorText(textMessage);
+    };
+
+    api.syncCsrfValue = function (csrfPayload) {
+        if (!api.hasCsrf()) {
+            return false;
+        }
+
+        if (!csrfPayload || typeof csrfPayload !== 'object') {
+            return false;
+        }
+
+        if (typeof csrfPayload.key === 'string' && csrfPayload.key !== '') {
+            csrf.key = csrfPayload.key;
+        }
+
+        if (typeof csrfPayload.token === 'string' && csrfPayload.token !== '') {
+            csrf.token = csrfPayload.token;
+            return true;
+        }
+
+        return false;
+    };
 
     const addCsrfToUrl = function (url) {
-        if (typeof csrf === 'undefined') {
+        if (!api.hasCsrf()) {
             return url;
         }
         const u = new URL(url, window.location.origin);
@@ -18,12 +84,140 @@ const photoboothTools = (function () {
         return u.toString();
     };
 
-    // Attach CSRF to all jQuery AJAX calls
-    if (typeof $ !== 'undefined' && typeof csrf !== 'undefined') {
-        $.ajaxSetup({
-            data: { [csrf.key]: csrf.token }
-        });
-    }
+    api.addCsrfToPayload = function (payload = {}) {
+        if (!api.hasCsrf()) {
+            return payload;
+        }
+
+        const csrfKey = csrf.key;
+        const csrfToken = csrf.token;
+
+        if (payload instanceof FormData) {
+            if (typeof payload.set === 'function') {
+                payload.set(csrfKey, csrfToken);
+            } else {
+                if (typeof payload.delete === 'function') {
+                    payload.delete(csrfKey);
+                }
+                payload.append(csrfKey, csrfToken);
+            }
+            return payload;
+        }
+
+        if (payload instanceof URLSearchParams) {
+            payload.set(csrfKey, csrfToken);
+            return payload;
+        }
+
+        if (typeof payload === 'string') {
+            const params = new URLSearchParams(payload);
+            params.set(csrfKey, csrfToken);
+            return params.toString();
+        }
+
+        if (payload === null || typeof payload === 'undefined') {
+            return { [csrfKey]: csrfToken };
+        }
+
+        if (typeof payload === 'object') {
+            return {
+                ...payload,
+                [csrfKey]: csrfToken
+            };
+        }
+
+        return payload;
+    };
+
+    api.refreshCsrfToken = async function () {
+        if (!api.hasCsrf()) {
+            return false;
+        }
+
+        if (api.csrfRefreshPromise) {
+            return api.csrfRefreshPromise;
+        }
+
+        api.csrfRefreshPromise = fetch(environment.publicFolders.api + '/csrf.php', {
+            method: 'GET',
+            cache: 'no-store',
+            credentials: 'same-origin'
+        })
+            .then(async (response) => {
+                if (!response.ok) {
+                    return false;
+                }
+
+                const csrfPayload = await response.json();
+                return api.syncCsrfValue(csrfPayload);
+            })
+            .catch(() => false)
+            .finally(() => {
+                api.csrfRefreshPromise = null;
+            });
+
+        return api.csrfRefreshPromise;
+    };
+
+    api.handleCsrfMismatch = function (context = '') {
+        if (api.csrfReloadScheduled) {
+            return;
+        }
+
+        api.csrfReloadScheduled = true;
+        const message = 'Session expired. Reloading...';
+        api.console.log('CSRF mismatch detected.', context);
+        api.overlay.showWarning(message);
+        setTimeout(() => {
+            api.reloadPage();
+        }, 750);
+    };
+
+    api.ajaxWithCsrf = function (ajaxOptions, retryOnCsrf = true) {
+        const requestOptions = {
+            ...ajaxOptions,
+            data: api.addCsrfToPayload(ajaxOptions.data)
+        };
+
+        const deferred = $.Deferred();
+
+        $.ajax(requestOptions)
+            .done((data, textStatus, jqXHR) => {
+                deferred.resolve(data, textStatus, jqXHR);
+            })
+            .fail((xhr, textStatus, errorThrown) => {
+                if (retryOnCsrf && api.isCsrfErrorResponse(xhr)) {
+                    api.refreshCsrfToken()
+                        .then((refreshed) => {
+                            if (!refreshed) {
+                                api.handleCsrfMismatch(requestOptions.url || 'unknown');
+                                deferred.reject(xhr, textStatus, errorThrown);
+                                return;
+                            }
+
+                            api.ajaxWithCsrf(ajaxOptions, false)
+                                .done((retryData, retryStatus, retryXhr) => {
+                                    deferred.resolve(retryData, retryStatus, retryXhr);
+                                })
+                                .fail((retryErrXhr, retryErrStatus, retryErrThrown) => {
+                                    if (api.isCsrfErrorResponse(retryErrXhr)) {
+                                        api.handleCsrfMismatch(requestOptions.url || 'unknown');
+                                    }
+                                    deferred.reject(retryErrXhr, retryErrStatus, retryErrThrown);
+                                });
+                        })
+                        .catch(() => {
+                            api.handleCsrfMismatch(requestOptions.url || 'unknown');
+                            deferred.reject(xhr, textStatus, errorThrown);
+                        });
+                    return;
+                }
+
+                deferred.reject(xhr, textStatus, errorThrown);
+            });
+
+        return deferred.promise();
+    };
 
     api.initialize = async function () {
         const resultTranslations = await fetch(addCsrfToUrl(environment.publicFolders.api + '/translations.php'), {
@@ -334,6 +528,10 @@ const photoboothTools = (function () {
             .then(function (response) {
                 if (response.status === 200) {
                     return response.text();
+                } else if (response.status === 403) {
+                    return response.text().then((bodyText) => {
+                        throw new Error(bodyText || 'Forbidden');
+                    });
                 } else if (response.status === 404) {
                     throw new Error('No records found');
                 } else {
@@ -344,6 +542,10 @@ const photoboothTools = (function () {
                 api.console.log(data);
             })
             .catch(function (error) {
+                if (api.isCsrfErrorText(error.message)) {
+                    api.handleCsrfMismatch(url);
+                    return;
+                }
                 api.console.log('Error occurred: ' + error.message);
             });
     };

--- a/lib/boot.php
+++ b/lib/boot.php
@@ -23,12 +23,49 @@ $isHttps = (!empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off')
 // Longer-lived sessions for kiosk use
 ini_set('session.gc_maxlifetime', 172800);   // 48h server-side lifetime
 ini_set('session.cookie_lifetime', 172800);  // 48h client cookie lifetime
+ini_set('session.gc_probability', '1');
+ini_set('session.gc_divisor', '100');
 
 session_set_cookie_params([
     'httponly' => true,
     'samesite' => 'Lax',
     'secure' => $isHttps,
 ]);
+
+// Keep sessions outside the public web root so session files are never web-accessible.
+$sessionCandidates = [
+    dirname(dirname(__DIR__)) . '/sessions',
+    sys_get_temp_dir() . '/photobooth-sessions',
+];
+
+$documentRoot = realpath((string)($_SERVER['DOCUMENT_ROOT'] ?? '')) ?: '';
+foreach ($sessionCandidates as $sessionPath) {
+    if (!is_dir($sessionPath)) {
+        @mkdir($sessionPath, 0700, true);
+    }
+
+    if (!is_dir($sessionPath) || !is_writable($sessionPath)) {
+        continue;
+    }
+
+    $resolvedPath = realpath($sessionPath) ?: $sessionPath;
+    if ($documentRoot !== '' && str_starts_with($resolvedPath, $documentRoot . DIRECTORY_SEPARATOR)) {
+        continue;
+    }
+
+    session_save_path($resolvedPath);
+    break;
+}
+
+// Cleanup legacy sessions that may still exist in a formerly public path.
+$legacyPublicSessionPath = dirname(__DIR__) . '/var/sessions';
+if (is_dir($legacyPublicSessionPath) && is_writable($legacyPublicSessionPath)) {
+    foreach (glob($legacyPublicSessionPath . DIRECTORY_SEPARATOR . 'sess_*') ?: [] as $legacySessionFile) {
+        @unlink($legacySessionFile);
+    }
+    @rmdir($legacyPublicSessionPath);
+}
+
 session_start();
 
 // Ensure a CSRF token exists for client-side requests

--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -122,6 +122,7 @@
   "commands:take_picture_cmd": "Take picture command",
   "commands:take_video_cmd": "Command to take a video",
   "confirm": "confirm",
+  "csrf_session_reloading": "Session expired. Reloading...",
   "current_version": "Installed:",
   "currentPhpVersion": "Current PHP version:",
   "custom": "Custom",


### PR DESCRIPTION
<!--
    Thank you for contributing!
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/PhotoboothProject/photobooth/blob/dev/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "x" next to an item)

- [ ] Documentation update
- [x] Bug fix
- [ ] New feature
- [ ] Other, please explain:

Fixes intermittent **403 / Invalid CSRF token** on POST APIs that already use CSRF (`shellCommand`, `capture`, `previewCamera`, `applyEffects`, `applyVideoEffects`) by syncing the token after session drift and hardening session storage.

<!--
    Please ensure your pull request is ready:

    - Please run 'npm run build' before submitting to have consistent formatting for both JavaScript & SCSS
    - Please run 'npm run eslint' to make sure there's no lint issues
-->


#### What changes did you make? (Give an overview)

- **`api/csrf.php`**: JSON endpoint to read the current session CSRF token (GET, no-store).
- **`assets/js/tools.js`**: `ajaxWithCsrf` (attach token, one retry after `csrf.php` refresh), explicit CSRF-403 detection, `getRequest` 403 handling; user message via **`csrf_session_reloading`** in `en.json`.
- **`core.js`**, **`preview.js`**, **`admin/index.js`**: affected calls use `ajaxWithCsrf` instead of stale global token / raw `$.ajax` where needed.
- **`lib/boot.php`**: session save path outside document root (with fallback), GC ini tweaks, cleanup of legacy `var/sessions`.
- Branch includes **merge from `dev`** (resolve `admin/index.js` header: `photoboothTools` + `eslint-env browser`).

#### Is there anything you'd like reviewers to focus on?

- Session directory **permissions** on real installs (`/var/www/sessions` or temp fallback).
- **One-time** effect of deleting legacy `var/sessions` (users re-login).

#### AI used to create this Pull Request?

Yes, in part: implementation and wording were assisted; changes were reviewed and eslint-checked locally.