### PR TITLE
SetupWizard: allow autostart if /etc/xdg/autostart exists

### DIFF
--- a/install-photobooth.sh
+++ b/install-photobooth.sh
@@ -3512,7 +3512,7 @@ function configure_shortcuts() {
             MENU_OPTIONS+=(
                 "2" "Disable Browser Autostart"
             )
-        elif ! is_wayland_env && [ "$WEBBROWSER" != "unknown" ] && [ "$PHOTOBOOTH_FOUND" = true ]; then
+        elif [ -d "/etc/xdg/autostart" ] && [ "$WEBBROWSER" != "unknown" ] && [ "$PHOTOBOOTH_FOUND" = true ]; then
             MENU_OPTIONS+=(
                 "2" "Enable Autostart in Kiosk Mode ($WEBBROWSER)"
             )
@@ -3544,7 +3544,7 @@ function configure_shortcuts() {
                     else
                         confirm "Autostart Disabled" "Failed to disable browser autostart in kiosk mode!"
                     fi
-                elif ! is_wayland_env; then
+                elif [ -d "/etc/xdg/autostart" ]; then
                     if browser_autostart; then
                         confirm "Autostart Enabled" "Browser autostart in kiosk mode has been enabled."
                     else


### PR DESCRIPTION
<!--
    Thank you for contributing!
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/PhotoboothProject/photobooth/blob/dev/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "x" next to an item)
<!-- Example:
- [x] Bug fix
-->

- [ ] Documentation update
- [x] Bug fix
- [ ] New feature
- [ ] Other, please explain:

<!--
    Please ensure your pull request is ready:

    - Please run 'npm run build' before submitting to have consistent formatting for both JavaScript & SCSS
    - Please run 'npm run eslint' to make sure there's no lint issues
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)

Adjust autostart check to check for /etc/xdg/autostart instead of Wayland setup (PiOS).

#### Is there anything you'd like reviewers to focus on?


#### AI used to create this Pull Request?
<!--
If AI was used to create this Pull Request please tell about the impact to submitted changes in detail.
-->
No.