### PR TITLE
fix: Installationdescription not working

### DIFF
--- a/docs/install/install-debian.md
+++ b/docs/install/install-debian.md
@@ -8,11 +8,32 @@ If you encounter any issues or want more freedom to configure your Pi, Computer 
 
 The steps below were tested on "Raspberry Pi OS with desktop" based on Debian Buster, but should work for Debian and all Debian based distributions. Photobooth can also be used on any other PC/Laptop running a supported OS.
 
+---
+
 ## Update your system
 
 ```
 sudo apt update
 sudo apt dist-upgrade
+```
+
+## Install Node.js & npm
+
+Photobooth requires:
+
+- **Node.js ≥ 20.15.0**
+- **npm ≥ 10.7.0**
+
+Install Node.js and npm from the official NodeSource repository:
+
+```
+curl -fsSL https://deb.nodesource.com/setup_20.x | sudo -E bash -
+sudo apt install -y nodejs
+```
+Verify
+```
+node -v
+npm -v
 ```
 
 ## Install a Webserver
@@ -38,7 +59,7 @@ sudo apt install -y nginx php-fpm
 ## Install dependencies
 
 ```
-sudo apt install -y curl gcc g++ make git ffmpeg gphoto2 libimage-exiftool-perl nodejs php-xml php-gd php-zip php-mbstring python3 python3-gphoto2 python3-psutil python3-zmq rsync udisks2 v4l2loopback-dkms v4l-utils
+sudo apt install -y curl gcc g++ make git ffmpeg gphoto2 libimage-exiftool-perl php-xml php-gd php-zip php-mbstring python3 python3-gphoto2 python3-psutil python3-zmq rsync udisks2 v4l2loopback-dkms v4l-utils
 ```
 
 **Optional:** If you have a new camera, you can also install the latest version of libgphoto2 directly from the maintainer. Choose "Install last stable release":

--- a/docs/install/install-debian.md
+++ b/docs/install/install-debian.md
@@ -8,8 +8,6 @@ If you encounter any issues or want more freedom to configure your Pi, Computer 
 
 The steps below were tested on "Raspberry Pi OS with desktop" based on Debian Buster, but should work for Debian and all Debian based distributions. Photobooth can also be used on any other PC/Laptop running a supported OS.
 
----
-
 ## Update your system
 
 ```


### PR DESCRIPTION
<!--
    Thank you for contributing!
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/PhotoboothProject/photobooth/blob/dev/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "x" next to an item)
<!-- Example:
- [x] Bug fix
-->

- [x] Documentation update
- [x] Bug fix
- [ ] New feature
- [ ] Other, please explain:

<!--
This PR fixes the Debian installation documentation regarding Node.js and npm requirements.

A new prerequisites section was added to explicitly install a compatible Node.js and npm version using NodeSource.

Additionally:
- removed `nodejs` from the generic dependency list
- clarified required Node.js/npm versions
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)
This PR fixes the Debian installation documentation regarding Node.js and npm requirements.

A new prerequisites section was added to explicitly install a compatible Node.js and npm version using NodeSource.

Additionally:
- removed `nodejs` from the generic dependency list
- clarified required Node.js/npm versions

#### Is there anything you'd like reviewers to focus on?
The current Debian installation instructions lead to a failing build on Debian 13.

Following the existing documentation:
- `nodejs` is installed via apt
- `npm` is either missing or too old (Debian provides npm 9.2.0)

This results in:
``
npm ERR! code EBADENGINE
``

Required:
- node >= 20.15.0
- npm >= 10.7.0
- 

The required versions are also documented in the prerequisites:
https://photoboothproject.github.io/install/prerequisites/

However, the Debian installation currently installs incompatible versions via apt.

Fixes #1482

#### AI used to create this Pull Request?
No
