### PR TITLE
Fix: prevent label descender clipping in modern_squared (fixes #1550)

### DIFF
--- a/assets/sass/components/_button.scss
+++ b/assets/sass/components/_button.scss
@@ -114,6 +114,7 @@
   }
 
   .button--label {
+    line-height: 1.2;
     text-overflow: ellipsis;
     overflow: hidden;
     max-width: calc(100% - 1rem);


### PR DESCRIPTION
#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/PhotoboothProject/photobooth/blob/dev/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "x" next to an item)

- [ ] Documentation update
- [x] Bug fix
- [ ] New feature
- [ ] Other, please explain:

#### What changes did you make? (Give an overview)

This PR fixes clipped descenders in home screen button labels when using `modern_squared` UI buttons.

- Updated `assets/sass/components/_button.scss`
- Added `line-height: 1.2` to `[data-ui-button='modern_squared'] .button--label`

This prevents letters like `g`, `p`, `q`, `y`, and `j` from being cut off while keeping existing truncation behavior (`text-overflow: ellipsis` + `overflow: hidden`).

Fixes #1550.

#### Is there anything you'd like reviewers to focus on?

Please verify visual behavior on the home screen with `modern_squared` buttons, especially labels containing descenders (e.g. `Collage`).

#### AI used to create this Pull Request?

AI was used to help identify and implement a minimal CSS fix.
Impact to submitted changes: one targeted style adjustment (`line-height: 1.2`) in a single SCSS selector.
