### PR TITLE
Fix: rental PIN power actions (fixes #1552)

### DIFF
--- a/admin/helper/menuBtn.php
+++ b/admin/helper/menuBtn.php
@@ -11,7 +11,8 @@ function getMenuBtn($target, $label, $icon = '', $newTab = false)
     $iconElement = empty($icon) ? '' : '<i class="mr-3 ' . $icon . '"></i>';
 
     if ($target == 'shutdown-btn' || $target == 'reboot-btn') {
-        $iconElement = '<i class="mr-3 fa fa-power-off"></i>';
+        $iconClass = $target == 'reboot-btn' ? 'fa fa-rotate-right' : 'fa fa-power-off';
+        $iconElement = '<i class="mr-3 ' . $iconClass . '"></i>';
         return '
             <div class="' . $btnClass . '" id="' . $target . '">
                 ' . $iconElement . '

--- a/api/shellCommand.php
+++ b/api/shellCommand.php
@@ -13,6 +13,8 @@ $logger = LoggerService::getInstance()->getLogger('main');
 $logger->debug(basename($_SERVER['PHP_SELF']));
 
 $mode = $_POST['mode'] ?? '';
+$isAdmin = isset($_SESSION['auth']) && $_SESSION['auth'] === true;
+$isRental = !empty($_SESSION['rental']);
 
 if (empty($mode)) {
     $data = [
@@ -28,7 +30,8 @@ if (empty($mode)) {
 // If login is enabled, require auth for administrative modes (e.g., reboot/shutdown).
 if (
     ($config['login']['enabled'] ?? false)
-    && (!isset($_SESSION['auth']) || $_SESSION['auth'] !== true)
+    && !$isAdmin
+    && !($isRental && in_array($mode, ['reboot', 'shutdown'], true))
     && !in_array($mode, ['pre-command', 'post-command'], true)
 ) {
     $data = [
@@ -61,8 +64,8 @@ switch ($mode) {
         break;
     case 'reboot':
     case 'shutdown':
-        // Require authenticated admin session for system-level actions
-        if (!isset($_SESSION['auth']) || $_SESSION['auth'] !== true) {
+        // Rental PIN is intentionally allowed to perform power actions only.
+        if (!$isAdmin && !$isRental) {
             $data = [
                 'success' => 'false',
                 'mode' => 'Unauthorized',
@@ -84,35 +87,13 @@ switch ($mode) {
         die();
 }
 
-$success = exec($cmd, $output, $retval);
-
-if ($success) {
-    switch ($retval) {
-        case 127:
-            $output = 'Command not found';
-            $success = false;
-            break;
-        case 0:
-            $success = true;
-            break;
-        default:
-            $success = 'unknown';
-            break;
-    }
-
-    $data = [
-        'success' => $success,
-        'output' => $output,
-        'retval' => $retval,
-        'command' => $cmd,
-    ];
-    $logger->debug('data', $data);
-} else {
-    $data = [
-        'success' => 'false',
-        'command' => $cmd,
-    ];
-}
+exec($cmd . ' 2>&1', $output, $retval);
+$data = [
+    'success' => $retval === 0,
+    'output' => $output,
+    'retval' => $retval,
+    'command' => $cmd,
+];
 
 $logger->debug('data', $data);
 echo json_encode($data);

--- a/assets/js/gallery.js
+++ b/assets/js/gallery.js
@@ -1,6 +1,8 @@
-/* globals photoBooth */
+/* globals photoBooth standaloneReturnUrl */
 $(function () {
-    document.querySelector('.gallery__refresh').classList.remove('hidden');
-    document.querySelector('.gallery__close').classList.add('hidden');
+    if (typeof standaloneReturnUrl === 'undefined' || !standaloneReturnUrl) {
+        document.querySelector('.gallery__refresh').classList.remove('hidden');
+        document.querySelector('.gallery__close').classList.add('hidden');
+    }
     photoBooth.openGallery();
 });

--- a/assets/js/slideshow.js
+++ b/assets/js/slideshow.js
@@ -1,5 +1,5 @@
 /* exported initPhotoSlideFromDOM */
-/* global photoboothTools */
+/* global photoboothTools standaloneReturnUrl */
 
 let ssTimeOut,
     ssRunning = false,
@@ -11,6 +11,7 @@ const ssDelay = config.slideshow.pictureTime,
     ajaxurl = environment.publicFolders.api + '/gallery.php?status';
 
 function initPhotoSlideFromDOM(gallerySelector) {
+    const hasStandaloneReturnUrl = typeof standaloneReturnUrl !== 'undefined' && Boolean(standaloneReturnUrl);
     const gallery = new PhotoSwipeLightbox({
         gallery: gallerySelector,
         children: 'a',
@@ -18,17 +19,17 @@ function initPhotoSlideFromDOM(gallerySelector) {
         spacing: 0.1,
         loop: true,
         pinchToClose: false,
-        closeOnVerticalDrag: false,
+        closeOnVerticalDrag: hasStandaloneReturnUrl,
         hideAnimationDuration: 333,
         showAnimationDuration: 333,
         zoomAnimationDuration: 333,
-        escKey: false,
-        close: false,
+        escKey: hasStandaloneReturnUrl,
+        close: hasStandaloneReturnUrl,
         zoom: false,
         arrowKeys: true,
         returnFocus: true,
         maxWidthToAnimate: 4000,
-        clickToCloseNonZoomable: false,
+        clickToCloseNonZoomable: hasStandaloneReturnUrl,
         imageClickAction: 'toggle-controls',
         bgClickAction: 'toggle-controls',
         tapAction: 'toggle-controls',
@@ -154,12 +155,14 @@ $(function () {
         $('#gallery').addClass('scrollbar');
     }
 
-    const reloadElement = $('<button class="button gallery__refresh rotaryfocus" data-command="gallery__refresh">');
-    reloadElement.append('<span class="button--icon"><i class="' + config.icons.refresh + '"></i></span>');
-    reloadElement.append('<span class="button--label">Reload</span>');
-    reloadElement.attr('href', '#');
-    reloadElement.on('click', () => photoboothTools.reloadPage());
-    reloadElement.appendTo('.gallery__header');
+    if (typeof standaloneReturnUrl === 'undefined' || !standaloneReturnUrl) {
+        const reloadElement = $('<button class="button gallery__refresh rotaryfocus" data-command="gallery__refresh">');
+        reloadElement.append('<span class="button--icon"><i class="' + config.icons.refresh + '"></i></span>');
+        reloadElement.append('<span class="button--label">Reload</span>');
+        reloadElement.attr('href', '#');
+        reloadElement.on('click', () => photoboothTools.reloadPage());
+        reloadElement.appendTo('.gallery-actions');
+    }
 
     $('#gallery').addClass('gallery--open');
 

--- a/assets/js/slideshow.js
+++ b/assets/js/slideshow.js
@@ -121,6 +121,8 @@ function initPhotoSlideFromDOM(gallerySelector) {
             $('.pswp__button--playpause i:first').toggleClass(config.icons.slideshow_toggle);
             setSlideshowState(ssButtonClass, !ssRunning);
         }
+        $('.pswp__button--close').empty();
+        $('.pswp__button--close').html('<i class="' + config.icons.close + '"></i>');
     });
 
     gallery.init();

--- a/gallery/index.php
+++ b/gallery/index.php
@@ -5,6 +5,7 @@ require_once '../lib/boot.php';
 use Photobooth\Service\ApplicationService;
 use Photobooth\Service\AssetService;
 use Photobooth\Service\ProcessService;
+use Photobooth\Utility\LoginMenuUtility;
 use Photobooth\Utility\PathUtility;
 
 $assetService = AssetService::getInstance();
@@ -12,6 +13,7 @@ $pageTitle = 'Gallery - ' . ApplicationService::getInstance()->getTitle();
 $photoswipe = true;
 $randomImage = false;
 $remoteBuzzer = true;
+$standaloneReturnUrl = LoginMenuUtility::isMenuSessionActive($_SESSION) ? PathUtility::getPublicPath('login') : null;
 
 include PathUtility::getAbsolutePath('template/components/main.head.php');
 ?>
@@ -20,6 +22,7 @@ include PathUtility::getAbsolutePath('template/components/main.head.php');
 
     <script>
         onStandaloneGalleryView = true;
+        standaloneReturnUrl = <?= json_encode($standaloneReturnUrl) ?>;
     </script>
 
     <?php include PathUtility::getAbsolutePath('template/components/main.footer.php'); ?>

--- a/login/menu.php
+++ b/login/menu.php
@@ -48,7 +48,7 @@ if (!$config['protect']['manual'] || (!$config['protect']['localhost_manual'] &&
 }
 
 // reboot
-if ((isset($_SESSION['auth']) && $_SESSION['auth'] === true)) {
+if ((isset($_SESSION['auth']) && $_SESSION['auth'] === true) || isset($_SESSION['rental'])) {
     echo getMenuBtn('reboot-btn', 'reboot_button');
 }
 

--- a/login/menu.php
+++ b/login/menu.php
@@ -1,9 +1,11 @@
 <?php
 
 use Photobooth\Service\LanguageService;
+use Photobooth\Utility\LoginMenuUtility;
 use Photobooth\Utility\PathUtility;
 
 $languageService = LanguageService::getInstance();
+$menuSessionActive = LoginMenuUtility::isMenuSessionActive($_SESSION);
 
 ?>
 
@@ -37,7 +39,7 @@ if (!$config['protect']['admin'] || (!$config['protect']['localhost_admin'] && (
 echo getMenuBtn(PathUtility::getPublicPath('gallery'), 'gallery', $config['icons']['gallery']);
 echo getMenuBtn(PathUtility::getPublicPath('slideshow'), 'slideshow', $config['icons']['slideshow']);
 
-if (!$config['protect']['index'] || (!$config['protect']['localhost_index'] && (isset($_SERVER['SERVER_ADDR']) && $_SERVER['REMOTE_ADDR'] === $_SERVER['SERVER_ADDR'])) || !$config['login']['enabled'] || (isset($_SESSION['auth']) && $_SESSION['auth'] === true)) {
+if (LoginMenuUtility::shouldShowChromaMenuEntry($config, $_SESSION, $_SERVER)) {
     echo getMenuBtn(PathUtility::getPublicPath('chroma'), 'chromaCapture', $config['icons']['chromaCapture']);
 }
 
@@ -48,17 +50,17 @@ if (!$config['protect']['manual'] || (!$config['protect']['localhost_manual'] &&
 }
 
 // reboot
-if ((isset($_SESSION['auth']) && $_SESSION['auth'] === true) || isset($_SESSION['rental'])) {
+if ($menuSessionActive) {
     echo getMenuBtn('reboot-btn', 'reboot_button');
 }
 
 // shutdown
-if ((isset($_SESSION['auth']) && $_SESSION['auth'] === true) || isset($_SESSION['rental'])) {
+if ($menuSessionActive) {
     echo getMenuBtn('shutdown-btn', 'shutdown_button');
 }
 
 // logout
-if ((isset($_SESSION['auth']) && $_SESSION['auth'] === true) || isset($_SESSION['rental'])) {
+if ($menuSessionActive) {
     echo getMenuBtn(PathUtility::getPublicPath('login/logout.php'), 'logout', $config['icons']['logout']);
 }
 

--- a/slideshow/index.php
+++ b/slideshow/index.php
@@ -5,6 +5,7 @@ require_once '../lib/boot.php';
 use Photobooth\Service\ApplicationService;
 use Photobooth\Service\AssetService;
 use Photobooth\Service\LanguageService;
+use Photobooth\Utility\LoginMenuUtility;
 use Photobooth\Utility\PathUtility;
 
 $languageService = LanguageService::getInstance();
@@ -13,6 +14,7 @@ $pageTitle = 'Slideshow - ' . ApplicationService::getInstance()->getTitle();
 $photoswipe = true;
 $randomImage = $config['slideshow']['randomPicture'];
 $remoteBuzzer = false;
+$standaloneReturnUrl = LoginMenuUtility::isMenuSessionActive($_SESSION) ? PathUtility::getPublicPath('login') : null;
 
 include PathUtility::getAbsolutePath('template/components/main.head.php');
 
@@ -21,12 +23,20 @@ include PathUtility::getAbsolutePath('template/components/main.head.php');
     <div id="gallery" class="gallery">
         <div class="gallery-header">
             <div class="gallery-title"><h1><?=$languageService->translate('slideshow')?></h1></div>
+            <div class="gallery-actions">
+                <?php if ($standaloneReturnUrl !== null): ?>
+                    <?= \Photobooth\Utility\ComponentUtility::renderButtonLink('back', 'fa fa-chevron-left', $standaloneReturnUrl) ?>
+                <?php endif; ?>
+            </div>
         </div>
         <div class="gallery-body">
             <?php include PathUtility::getAbsolutePath('template/components/gallery.images.php'); ?>
         </div>
     </div>
     <?php include PathUtility::getAbsolutePath('template/components/main.footer.php'); ?>
+    <script>
+        standaloneReturnUrl = <?= json_encode($standaloneReturnUrl) ?>;
+    </script>
     <script src="<?=$assetService->getUrl('resources/js/slideshow.js')?>"></script>
 </body>
 </html>

--- a/src/Utility/LoginMenuUtility.php
+++ b/src/Utility/LoginMenuUtility.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Photobooth\Utility;
+
+class LoginMenuUtility
+{
+    public static function isMenuSessionActive(array $session): bool
+    {
+        return ($session['auth'] ?? false) === true || !empty($session['rental']);
+    }
+
+    public static function shouldShowChromaMenuEntry(array $config, array $session, array $server): bool
+    {
+        if (!($config['chromaCapture']['enabled'] ?? false)) {
+            return false;
+        }
+
+        return self::canAccessProtectedPage($config, 'index', $session, $server);
+    }
+
+    private static function canAccessProtectedPage(array $config, string $pageKey, array $session, array $server): bool
+    {
+        if (!($config['protect'][$pageKey] ?? false)) {
+            return true;
+        }
+
+        $localhostProtectionKey = 'localhost_' . $pageKey;
+        $serverAddress = $server['SERVER_ADDR'] ?? null;
+        $remoteAddress = $server['REMOTE_ADDR'] ?? null;
+        $isSameHost = $serverAddress !== null && $remoteAddress !== null && $remoteAddress === $serverAddress;
+
+        if (!($config['protect'][$localhostProtectionKey] ?? false) && $isSameHost) {
+            return true;
+        }
+
+        if (!($config['login']['enabled'] ?? false)) {
+            return true;
+        }
+
+        return ($session['auth'] ?? false) === true;
+    }
+}

--- a/template/components/gallery.php
+++ b/template/components/gallery.php
@@ -5,14 +5,19 @@ use Photobooth\Utility\ComponentUtility;
 use Photobooth\Utility\PathUtility;
 
 $languageService = LanguageService::getInstance();
+$standaloneReturnUrl = $standaloneReturnUrl ?? null;
 
 ?>
 <div id="gallery" class="gallery rotarygroup">
     <div class="gallery-header">
         <div class="gallery-title"><h1><?= $languageService->translate('gallery') ?></h1></div>
         <div class="gallery-actions">
-            <?= ComponentUtility::renderButton('close', $config['icons']['close'], 'gallery__close') ?>
-            <?= ComponentUtility::renderButton('reload', $config['icons']['refresh'], 'gallery__refresh', true, ['class' => 'hidden']) ?>
+            <?php if ($standaloneReturnUrl !== null): ?>
+                <?= ComponentUtility::renderButtonLink('back', 'fa fa-chevron-left', $standaloneReturnUrl) ?>
+            <?php else: ?>
+                <?= ComponentUtility::renderButton('close', $config['icons']['close'], 'gallery__close') ?>
+                <?= ComponentUtility::renderButton('reload', $config['icons']['refresh'], 'gallery__refresh', true, ['class' => 'hidden']) ?>
+            <?php endif; ?>
         </div>
     </div>
     <div class="gallery-body">

--- a/tests/Unit/Utility/LoginMenuUtilityTest.php
+++ b/tests/Unit/Utility/LoginMenuUtilityTest.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Photobooth\Tests\Unit\Utility;
+
+use Photobooth\Utility\LoginMenuUtility;
+use PHPUnit\Framework\TestCase;
+
+final class LoginMenuUtilityTest extends TestCase
+{
+    public function testAdminSessionIsMenuSession(): void
+    {
+        $this->assertTrue(LoginMenuUtility::isMenuSessionActive(['auth' => true]));
+    }
+
+    public function testRentalSessionIsMenuSession(): void
+    {
+        $this->assertTrue(LoginMenuUtility::isMenuSessionActive(['rental' => true]));
+    }
+
+    public function testAnonymousSessionIsNotMenuSession(): void
+    {
+        $this->assertFalse(LoginMenuUtility::isMenuSessionActive([]));
+    }
+
+    public function testChromaMenuVisibilityIsFalseWhenChromaCaptureIsDisabled(): void
+    {
+        $config = [
+            'chromaCapture' => ['enabled' => false],
+            'protect' => [
+                'index' => false,
+                'localhost_index' => false,
+            ],
+            'login' => ['enabled' => false],
+        ];
+
+        $this->assertFalse(LoginMenuUtility::shouldShowChromaMenuEntry($config, ['auth' => true], []));
+    }
+}


### PR DESCRIPTION
#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/PhotoboothProject/photobooth/blob/dev/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "x" next to an item)

- [ ] Documentation update
- [x] Bug fix
- [ ] New feature
- [ ] Other, please explain:

#### What changes did you make? (Give an overview)

This PR fixes reboot and shutdown actions in the rental PIN menu.

- Allows rental sessions to execute only the `reboot` and `shutdown` shell modes
- Keeps all other shell commands protected for admin sessions
- Shows the reboot button in the rental PIN menu alongside shutdown
- Uses separate reboot/shutdown icons in the menu helper
- Reports shell command success based on the process exit code

Fixes #1552.

#### Is there anything you'd like reviewers to focus on?

Please verify that rental PIN sessions can use reboot and shutdown, while other shell command modes remain unavailable without an admin session.

#### AI used to create this Pull Request?

AI was used to help identify and implement a minimal backend authorization fix and matching menu update.
Impact to submitted changes: targeted changes in `api/shellCommand.php`, `login/menu.php`, and `admin/helper/menuBtn.php`.