### PR TITLE
Fix: capitalize German confirm label

### DIFF
--- a/resources/lang/de.json
+++ b/resources/lang/de.json
@@ -121,7 +121,7 @@
   "commands:take_collage_cmd": "Befehl um ein Collage-Bild aufzunehmen",
   "commands:take_picture_cmd": "Befehl zur Bildaufnahme",
   "commands:take_video_cmd": "Befehl zur Videoaufnahme",
-  "confirm": "bestätigen",
+  "confirm": "Bestätigen",
   "csrf_session_reloading": "Sitzung abgelaufen. Neuladen...",
   "current_version": "Installiert:",
   "currentPhpVersion": "Aktuelle PHP-Version:",


### PR DESCRIPTION
#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/PhotoboothProject/photobooth/blob/dev/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "x" next to an item)

- [ ] Documentation update
- [x] Bug fix
- [ ] New feature
- [ ] Other, please explain:

#### What changes did you make? (Give an overview)

This PR fixes the German confirm button label casing in the dialog UI.

- Updates `confirm` in `resources/lang/de.json` from `bestätigen` to `Bestätigen`
- Keeps behavior unchanged (translation-only fix)