### PR TITLE
ci: clear composer auth before build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,6 +51,9 @@ jobs:
       - name: Install modules
         run: npm install
 
+      - name: Cleanup Composer auth token
+        run: rm -f "$HOME/.composer/auth.json" "$HOME/.config/composer/auth.json"
+
       - name: Build
         run: npm run build
 


### PR DESCRIPTION
Seperate from #1553 