### PR TITLE
Fix: restart device_cam background stream after capture so rapid shots work on slow hardware

### DIFF
--- a/assets/js/core.js
+++ b/assets/js/core.js
@@ -1413,6 +1413,11 @@ const photoBooth = (function () {
             photoboothPreview.startVideo(CameraDisplayMode.INIT);
         }
 
+        if (usesBackgroundPreview) {
+            photoboothTools.console.logDev('Preview: core: restart background video from api.renderPic');
+            photoboothPreview.startVideo(CameraDisplayMode.BACKGROUND);
+        }
+
         if (config.commands.post_photo) {
             api.shellCommand('post-command', filename);
         }


### PR DESCRIPTION
This fix restarts the camera stream immediately after a photo is processed, so it's warm and ready before the user triggers the next shot.

## The bug

When using `preview.mode = device_cam`, `camTakesPic = true`, and `asBackground = true`, the camera stream is stopped during capture (`stopPreviewAndCaptureFromVideo`) but never restarted after `renderPic`. The stream only restarts when the next countdown begins — which on slow hardware (e.g. Raspberry Pi 3B+) is not enough time. The countdown finishes before the camera is ready, resulting in a blank/black capture on the second shot.

## The fix

Restart the background video stream in `renderPic` so the camera warms up while the user views the result, ready for the next shot. This mirrors the existing behaviour in collage mode, where `initializeMedia()` is called between shots to ensure the stream is ready before the next capture is triggered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)