### PR TITLE
fix(button): avoid sticky touch hover on iPad Safari

### DIFF
--- a/assets/sass/components/_button.scss
+++ b/assets/sass/components/_button.scss
@@ -54,8 +54,7 @@
   line-height: 1;
 
   &.focused,
-  &:hover,
-  &:focus {
+  &:focus-visible {
     --button-background: var(--button-focus-background);
   }
 
@@ -64,6 +63,12 @@
     display: flex;
     align-items: center;
     justify-content: center;
+  }
+}
+
+@media (hover: hover) and (pointer: fine) {
+  .button:hover {
+    --button-background: var(--button-focus-background);
   }
 }
 


### PR DESCRIPTION
#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/PhotoboothProject/photobooth/blob/dev/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "x" next to an item)

- [ ] Documentation update
- [x] Bug fix
- [ ] New feature
- [ ] Other, please explain:

#### What changes did you make? (Give an overview)

- limit button hover styling to devices that actually support hover with a fine pointer
- keep rotary highlighting on `.focused` and keyboard highlighting on `:focus-visible`
- avoid iPad Safari leaving a result action visually highlighted after touch interaction

#### Is there anything you'd like reviewers to focus on?

- whether restricting `.button:hover` to `@media (hover: hover) and (pointer: fine)` covers the intended desktop behavior without affecting rotary navigation

#### AI used to create this Pull Request?

- AI was used to help investigate the issue and update the final CSS change.
- Earlier focus-related experiments were discarded; the final fix is limited to `assets/sass/components/_button.scss`.
- Validation run for this change:
  - `npm run build:gulp`