### PR TITLE
fix: normalize linux hostname ip parsing

### DIFF
--- a/src/Environment.php
+++ b/src/Environment.php
@@ -35,8 +35,8 @@ class Environment implements \JsonSerializable
         }
 
         if (self::isLinux()) {
-            $ip = shell_exec('hostname -I | cut -d \" \" -f 1') ?: '';
-            $cachedIp = trim((string) $ip);
+            $ip = trim((string) (shell_exec('hostname -I') ?: ''));
+            $cachedIp = $ip === '' ? '' : (preg_split('/\s+/', $ip)[0] ?? '');
         } else {
             $cachedIp = isset($_SERVER['HTTP_HOST']) ? (string) $_SERVER['HTTP_HOST'] : '';
         }


### PR DESCRIPTION
#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/PhotoboothProject/photobooth/blob/dev/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "x" next to an item)

- [ ] Documentation update
- [x] Bug fix
- [ ] New feature
- [ ] Other, please explain:

#### What changes did you make? (Give an overview)

- simplify Linux IP detection by reading the full `hostname -I` output once
- trim the command output and select the first whitespace-separated address in PHP
- avoid depending on shell-side `cut` parsing for the cached environment IP

#### Is there anything you'd like reviewers to focus on?

- whether the first-address selection matches the expected behavior for Linux hosts with multiple addresses

#### AI used to create this Pull Request?

- AI was used to help prepare the small code change and PR text. The submitted change is limited to the `src/Environment.php` Linux IP parsing logic.
