### PR TITLE
fix: make public QR viewer self-contained

### DIFF
--- a/api/download.php
+++ b/api/download.php
@@ -7,6 +7,7 @@ use Photobooth\Enum\FolderEnum;
 require_once '../lib/boot.php';
 
 $image = (isset($_GET['image']) && $_GET['image']) != '' ? $_GET['image'] : false;
+$forceDownload = !isset($_GET['inline']) || $_GET['inline'] !== '1';
 if ($image) {
     $basename = basename($image);
     if ($basename === '' || !preg_match('/^[A-Za-z0-9._-]+$/', $basename)) {
@@ -37,9 +38,18 @@ if ($image) {
             }
         }
 
-        header('Content-Type: application/octet-stream');
+        $contentType = match (strtolower((string) $extension)) {
+            'png' => 'image/png',
+            'gif' => 'image/gif',
+            'webm' => 'video/webm',
+            'mov' => 'video/quicktime',
+            'mp4' => 'video/mp4',
+            default => 'image/jpeg',
+        };
+
+        header('Content-Type: ' . $contentType);
         header('Content-Length: ' . filesize($path));
-        header('Content-Disposition: attachment; filename="photobooth-' . $image . '"');
+        header('Content-Disposition: ' . ($forceDownload ? 'attachment' : 'inline') . '; filename="photobooth-' . $image . '"');
         echo file_get_contents($path);
     } catch (\Exception $e) {
         http_response_code(500);

--- a/view.php
+++ b/view.php
@@ -3,7 +3,6 @@
 use Photobooth\Enum\FolderEnum;
 use Photobooth\Service\ApplicationService;
 use Photobooth\Service\LanguageService;
-use Photobooth\Utility\ComponentUtility;
 use Photobooth\Utility\PathUtility;
 
 require_once __DIR__ . '/lib/boot.php';
@@ -31,52 +30,176 @@ $mime = match ($extension) {
     'gif' => 'image/gif',
     default => 'image/jpeg',
 };
-$imageUrl = PathUtility::getPublicPath(FolderEnum::IMAGES->value . '/' . rawurlencode($image));
+$imageUrl = PathUtility::getPublicPath('api/download.php?image=' . rawurlencode($image) . '&inline=1');
 $downloadUrl = PathUtility::getPublicPath('api/download.php?image=' . rawurlencode($image));
 $languageService = LanguageService::getInstance();
-$pageTitle = ApplicationService::getInstance()->getTitle() . ' - ' . $languageService->translate('viewer_photo_title');
-$photoswipe = false;
-$remoteBuzzer = false;
+$appTitle = ApplicationService::getInstance()->getTitle();
+$startScreenTitle = trim((string) ($config['start_screen']['title'] ?? ''));
+$viewerFallbackTitle = $startScreenTitle !== '' ? $startScreenTitle : $appTitle;
+$pageTitle = $appTitle . ' - ' . $languageService->translate('viewer_photo_title');
+$downloadLabel = $languageService->translate('download');
+$eventTitleLines = $config['event']['enabled']
+    ? array_values(array_filter([
+        $config['event']['textLeft'] ?? '',
+        $config['event']['textRight'] ?? '',
+    ], static fn ($line) => $line !== ''))
+    : [$viewerFallbackTitle];
 
-include PathUtility::getAbsolutePath('template/components/main.head.php');
+if ($eventTitleLines === []) {
+    $eventTitleLines = [$viewerFallbackTitle];
+}
 ?>
-<body class="viewer-page">
+<!DOCTYPE html>
+<html lang="<?= htmlspecialchars($config['ui']['language'] ?? 'en') ?>">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
+    <meta name="theme-color" content="<?= htmlspecialchars($config['colors']['status_bar'] ?? '#000000') ?>">
+    <title><?= htmlspecialchars($pageTitle) ?></title>
+    <link rel="icon" href='data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64"><rect width="64" height="64" rx="16" fill="%23<?= ltrim(htmlspecialchars($config['colors']['primary'] ?? '222222'), '#') ?>"/><circle cx="32" cy="32" r="14" fill="white"/><circle cx="32" cy="32" r="6" fill="%23<?= ltrim(htmlspecialchars($config['colors']['secondary'] ?? '555555'), '#') ?>"/></svg>'>
+    <style>
+        :root {
+            --viewer-bg: <?= htmlspecialchars($config['colors']['primary_light'] ?? '#f4f4f4') ?>;
+            --viewer-surface: #ffffff;
+            --viewer-primary: <?= htmlspecialchars($config['colors']['primary'] ?? '#222222') ?>;
+            --viewer-secondary: #6f675f;
+            --viewer-font: #1f1f1f;
+            --viewer-border: color-mix(in srgb, var(--viewer-primary), white 82%);
+            --viewer-button: <?= htmlspecialchars($config['colors']['primary'] ?? '#222222') ?>;
+            --viewer-button-text: #ffffff;
+        }
+
+        * {
+            box-sizing: border-box;
+        }
+
+        body {
+            margin: 0;
+            min-height: 100vh;
+            font-family: Inter, "Avenir Next", "Segoe UI", sans-serif;
+            color: var(--viewer-font);
+            background: var(--viewer-bg);
+            display: grid;
+            place-items: center;
+            padding: 16px;
+        }
+
+        .viewer {
+            width: min(920px, 100%);
+            background: transparent;
+        }
+
+        .viewer__inner {
+            background: var(--viewer-surface);
+            border-radius: 20px;
+            padding: 20px;
+            display: flex;
+            flex-direction: column;
+            gap: 18px;
+            border: 1px solid var(--viewer-border);
+            box-shadow: 0 18px 40px color-mix(in srgb, var(--viewer-primary), transparent 88%);
+        }
+
+        .viewer__title {
+            text-align: center;
+            display: flex;
+            flex-direction: column;
+            gap: 4px;
+            color: var(--viewer-primary);
+            font-family: "Baskerville", "Times New Roman", "Georgia", serif;
+            font-style: italic;
+            font-weight: 600;
+            font-size: clamp(28px, 4.8vw, 40px);
+            line-height: 1.05;
+            letter-spacing: 0;
+        }
+
+        .viewer__accent {
+            height: 4px;
+            border-radius: 999px;
+            background: linear-gradient(90deg, var(--viewer-primary), color-mix(in srgb, var(--viewer-primary), white 28%));
+        }
+
+        .viewer__media {
+            min-height: min(40vh, 320px);
+            max-height: 70vh;
+            border-radius: 16px;
+            overflow: hidden;
+            background: color-mix(in srgb, var(--viewer-bg), white 45%);
+            border: 1px solid var(--viewer-border);
+            display: grid;
+            place-items: center;
+            padding: 12px;
+        }
+
+        .viewer__media img,
+        .viewer__media video {
+            display: block;
+            max-width: 100%;
+            max-height: min(60vh, 720px);
+            width: auto;
+            height: auto;
+            object-fit: contain;
+            border-radius: 10px;
+        }
+
+        .viewer__actions {
+            display: flex;
+            justify-content: center;
+        }
+
+        .viewer__download {
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            min-height: 52px;
+            padding: 0 22px;
+            border-radius: 999px;
+            text-decoration: none;
+            font-weight: 700;
+            color: var(--viewer-button-text);
+            background: var(--viewer-button);
+            box-shadow: 0 10px 24px color-mix(in srgb, var(--viewer-primary), transparent 82%);
+        }
+
+        @media (max-width: 540px) {
+            .viewer__inner {
+                padding: 14px;
+            }
+
+            .viewer__media img,
+            .viewer__media video {
+                max-height: 52vh;
+            }
+        }
+    </style>
+</head>
+<body>
     <main class="viewer">
         <div class="viewer__inner">
-            <header class="viewer__header">
-                <div class="viewer__title">
-                    <?php if ($config['event']['enabled']): ?>
-                        <span class="viewer__title-line"><?= htmlspecialchars($config['event']['textLeft']) ?></span>
-                        <?php if (!empty($config['event']['symbol'])): ?>
-                            <span class="viewer__title-line">
-                                <i class="fa <?= htmlspecialchars($config['event']['symbol']) ?>" aria-hidden="true"></i>
-                            </span>
-                        <?php endif; ?>
-                        <span class="viewer__title-line"><?= htmlspecialchars($config['event']['textRight']) ?></span>
-                    <?php else: ?>
-                        <span class="viewer__title-line"><?= htmlspecialchars(ApplicationService::getInstance()->getTitle()) ?></span>
-                    <?php endif; ?>
-                </div>
+            <header class="viewer__title">
+                <?php foreach ($eventTitleLines as $line): ?>
+                    <span><?= htmlspecialchars($line) ?></span>
+                <?php endforeach; ?>
             </header>
             <div class="viewer__accent"></div>
 
             <div class="viewer__media" aria-label="Captured media preview">
                 <?php if ($isVideo): ?>
-                    <video src="<?=$imageUrl?>" controls playsinline controlsList="nodownload">
-                        <?=htmlspecialchars($languageService->translate('viewer_video_fallback'))?>
+                    <video src="<?= htmlspecialchars($imageUrl) ?>" controls playsinline controlsList="nodownload">
+                        <?= htmlspecialchars($languageService->translate('viewer_video_fallback')) ?>
                     </video>
                 <?php else: ?>
-                    <img id="viewer-image" src="<?=$imageUrl?>" alt="Captured photo">
+                    <img id="viewer-image" src="<?= htmlspecialchars($imageUrl) ?>" alt="Captured photo">
                 <?php endif; ?>
             </div>
 
-            <div class="viewer__actions buttonbar">
-                <?= ComponentUtility::renderButtonLink('download', $config['icons']['download'], $downloadUrl, true, ['download' => 'download']) ?>
+            <div class="viewer__actions">
+                <a class="viewer__download" href="<?= htmlspecialchars($downloadUrl) ?>" download="download">
+                    <?= htmlspecialchars($downloadLabel) ?>
+                </a>
             </div>
-
         </div>
     </main>
-
-    <?php include PathUtility::getAbsolutePath('template/components/main.footer.php'); ?>
 </body>
 </html>

--- a/view.php
+++ b/view.php
@@ -48,6 +48,12 @@ $eventTitleLines = $config['event']['enabled']
 if ($eventTitleLines === []) {
     $eventTitleLines = [$viewerFallbackTitle];
 }
+
+// Public event hosts may expose this viewer and api/download.php, but still 404
+// the usual Photobooth assets under /resources, /node_modules, /private and
+// api/settings.php. Keep this page self-contained unless those asset paths are
+// available again. As a consequence, shared JS/CSS, Font Awesome icons and the
+// actual configured custom font files are not used here.
 ?>
 <!DOCTYPE html>
 <html lang="<?= htmlspecialchars($config['ui']['language'] ?? 'en') ?>">


### PR DESCRIPTION
#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/PhotoboothProject/photobooth/blob/dev/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "x" next to an item)

- [ ] Documentation update
- [x] Bug fix
- [ ] New feature
- [ ] Other, please explain:

#### What changes did you make? (Give an overview)

This fixes the public QR viewer when the host only exposes `view.php` and `api/download.php`, but not the usual Photobooth asset paths.

- make `view.php` self-contained so it no longer depends on shared CSS/JS/font assets that 404 on the public host
- load the preview image through `api/download.php?inline=1` instead of a direct `data/images/...` URL
- extend `api/download.php` to support inline image/video responses while keeping normal download behavior unchanged
- use the configured event text when available and fall back to the start screen title if not

#### Is there anything you'd like reviewers to focus on?

Please focus on whether the standalone `view.php` approach is acceptable for public QR endpoints where the full asset tree is not reachable.

#### AI used to create this Pull Request?

AI was used to implement and describe the changes. The final diff was reviewed in the local checkout and validated with:

- `ddev php -l /var/www/html/view.php`
- `ddev php -l /var/www/html/api/download.php`
