### PR TITLE
Fix DDEV build with Node 20

### DIFF
--- a/.ddev/web-build/Dockerfile
+++ b/.ddev/web-build/Dockerfile
@@ -8,7 +8,6 @@ RUN apt-get update && \
 # Preinstall node 20 for consistency with project engines
 RUN curl -fsSL https://deb.nodesource.com/setup_20.x | bash - && \
     apt-get update && apt-get install -y --no-install-recommends nodejs && \
-    npm install -g npm@latest && \
     rm -rf /var/lib/apt/lists/*
 
 WORKDIR /var/www/html

--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,4 @@ tools/*/vendor
 scripts/rembg_venv/
 /.venv
 /site
+/.envrc


### PR DESCRIPTION
<!--
    Thank you for contributing!
-->

#### Prerequisites checklist

- [ ] I have read the [contributing guidelines](https://github.com/PhotoboothProject/photobooth/blob/dev/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "x" next to an item)

- [ ] Documentation update
- [x] Bug fix
- [ ] New feature
- [ ] Other, please explain:

#### What changes did you make? (Give an overview)

- Removed the unbounded global `npm@latest` upgrade from the DDEV web image.
- Added the local direnv `.envrc` file to `.gitignore`.

The image intentionally installs Node.js 20, but npm 12 now requires Node.js 22.22.2 or newer. NodeSource already bundles a compatible npm version with Node.js 20, so the extra upgrade caused `ddev start` to fail while building the image.

This restores a successful DDEV startup without changing the project's Node.js version and prevents local direnv configuration from being committed.

Validation:

- `ddev start`
- `ddev exec 'node --version && npm --version'` (`v20.20.2`, `10.8.2`)
- `ddev describe` (web service `OK`)
- `git diff --check`

#### Is there anything you'd like reviewers to focus on?

Please confirm that relying on the npm version bundled by the NodeSource Node.js 20 package is preferred over maintaining a separate npm major-version pin.

#### AI used to create this Pull Request?

Codex reproduced the DDEV image build failure, identified the Node.js/npm engine mismatch, applied the Dockerfile fix, and ran the validation listed above. It also assisted with adding `.envrc` to `.gitignore`.
