### PR TITLE
Allow screensaver file uploads

### DIFF
--- a/admin/upload/index.php
+++ b/admin/upload/index.php
@@ -74,6 +74,7 @@ if (isset($_POST['submit'])) {
                         <option value="private/images/cheese" <?= $folderName === 'private/images/cheese' ? 'selected' : '' ?>>images/cheese</option>
                         <option value="private/images/demo" <?= $folderName === 'private/images/demo' ? 'selected' : '' ?>>images/demo</option>
                         <option value="private/videos/background" <?= $folderName === 'private/videos/background' ? 'selected' : '' ?>>videos/background</option>
+                        <option value="private/screensavers" <?= $folderName === 'private/screensavers' ? 'selected' : '' ?>>screensavers</option>
                         <option value="private/fonts" <?= $folderName === 'private/fonts' ? 'selected' : '' ?>>fonts</option>
                     </select>
                     <label class="<?= $labelClass ?>" for="files"><?=$languageService->translate('upload_selection')?></label>

--- a/src/FileUploader.php
+++ b/src/FileUploader.php
@@ -53,7 +53,8 @@ class FileUploader
             'private/images/cheese' => ImageUtility::supportedMimeTypesSelect,
             'private/images/demo' => ImageUtility::supportedMimeTypesSelect,
             'private/fonts' => FontUtility::supportedMimeTypesSelect,
-            'private/videos/background' => VideoUtility::supportedMimeTypesSelect
+            'private/videos/background' => VideoUtility::supportedMimeTypesSelect,
+            'private/screensavers' => array_merge(ImageUtility::supportedMimeTypesSelect, VideoUtility::supportedMimeTypesSelect),
         ];
     }
 

--- a/tests/Unit/FileUploaderTest.php
+++ b/tests/Unit/FileUploaderTest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Photobooth\Tests\Unit;
+
+use Photobooth\FileUploader;
+use Photobooth\Logger\NamedLogger;
+use Photobooth\Utility\ImageUtility;
+use Photobooth\Utility\VideoUtility;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+
+final class FileUploaderTest extends TestCase
+{
+    public function testScreensaverFolderAcceptsImagesAndVideos(): void
+    {
+        $uploader = new FileUploader('private/screensavers', [], new NamedLogger('file-uploader-test', 0));
+        $reflection = new ReflectionClass($uploader);
+        $typeChecker = $reflection->getProperty('typeChecker')->getValue($uploader);
+
+        $this->assertEqualsCanonicalizing(
+            array_merge(ImageUtility::supportedMimeTypesSelect, VideoUtility::supportedMimeTypesSelect),
+            $typeChecker['private/screensavers'],
+        );
+    }
+}


### PR DESCRIPTION
<!--
    Thank you for contributing!
-->

#### Prerequisites checklist

- [ ] I have read the [contributing guidelines](https://github.com/PhotoboothProject/photobooth/blob/dev/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "x" next to an item)

- [ ] Documentation update
- [x] Bug fix
- [ ] New feature
- [ ] Other, please explain:

#### What changes did you make? (Give an overview)

- Added `screensavers` to the file uploader's destination-folder selection.
- Allowed `private/screensavers` in the server-side upload validation.
- Accepted both supported image and video MIME types for screensaver uploads.
- Added a unit test covering the combined screensaver MIME-type allowlist.

The screensaver configuration supports image and video files from `private/screensavers`, but the admin file uploader did not offer that folder and rejected it server-side. Users can now upload both screensaver asset types through the existing uploader.

Validation:

- PHP-CS-Fixer on the changed files
- PHP syntax checks for `admin/upload/index.php` and `src/FileUploader.php`
- `composer phpstan`
- `composer phpunit` (32 tests, 32 assertions)
- `git diff --check`

#### Is there anything you'd like reviewers to focus on?

Please verify that supporting both the existing image and video MIME-type lists matches the intended screensaver asset support.

#### AI used to create this Pull Request?

Codex traced the missing folder through the upload form and server-side allowlist, implemented the scoped fix, added the unit test, and ran the validation listed above.
