### PR TITLE
fix power actions

### DIFF
--- a/api/shellCommand.php
+++ b/api/shellCommand.php
@@ -64,16 +64,6 @@ switch ($mode) {
         break;
     case 'reboot':
     case 'shutdown':
-        // Rental PIN is intentionally allowed to perform power actions only.
-        if (!$isAdmin && !$isRental) {
-            $data = [
-                'success' => 'false',
-                'mode' => 'Unauthorized',
-            ];
-            $logger->debug('message', $data);
-            echo json_encode($data);
-            die();
-        }
         $sudoCmd = $mode === 'reboot' ? $config['commands']['reboot'] : $config['commands']['shutdown'];
         $cmd = 'sudo ' . sprintf($sudoCmd);
         break;


### PR DESCRIPTION
always allow power options if login is disabled

<!--
    Thank you for contributing!
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/PhotoboothProject/photobooth/blob/dev/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "x" next to an item)
<!-- Example:
- [x] Bug fix
-->

- [ ] Documentation update
- [x] Bug fix
- [ ] New feature
- [ ] Other, please explain:

<!--
    Please ensure your pull request is ready:

    - Please run 'npm run build' before submitting to have consistent formatting for both JavaScript & SCSS
    - Please run 'npm run eslint' to make sure there's no lint issues
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)
When login was disabled, the photobooth could not be shut down/rebooted anymore (if `isAdmin` and `isRental` are both `false`).
I removed the check inside the `shutdown` and `reboot` actions because the correct check (that also checks if login is enabled) is already there before the switch/case block: https://github.com/PhotoboothProject/photobooth/blob/43ce985fc8030a4513533a9584689943e6f824dd/api/shellCommand.php#L29-L44


#### Is there anything you'd like reviewers to focus on?
No

#### AI used to create this Pull Request?
<!--
If AI was used to create this Pull Request please tell about the impact to submitted changes in detail.
-->
No
